### PR TITLE
Remove explicit name in diagnosticSetting policy

### DIFF
--- a/samples/Monitoring/audit-diagnostic-setting/azurepolicy.json
+++ b/samples/Monitoring/audit-diagnostic-setting/azurepolicy.json
@@ -21,7 +21,6 @@
                 "effect": "AuditIfNotExists",
                 "details": {
                     "type": "Microsoft.Insights/diagnosticSettings",
-                    "name": "service",
                     "existenceCondition": {
                         "allOf": [
                             {

--- a/samples/Monitoring/audit-diagnostic-setting/azurepolicy.rules.json
+++ b/samples/Monitoring/audit-diagnostic-setting/azurepolicy.rules.json
@@ -7,7 +7,6 @@
 		"effect": "AuditIfNotExists",
 		"details": {
 			"type": "Microsoft.Insights/diagnosticSettings",
-			"name": "service",
 			"existenceCondition": {
 				"allOf": [
 					{


### PR DESCRIPTION
diagnosticSettings no longer have a constant name.  Need to evaluate all child diagnosticSettings.