### PR TITLE
The example sql-db-skus/azurepolicy.rules.json references wrong alias

### DIFF
--- a/samples/SQL/sql-db-skus/azurepolicy.rules.json
+++ b/samples/SQL/sql-db-skus/azurepolicy.rules.json
@@ -9,11 +9,11 @@
 				"not": {
 					"anyOf": [
 						{
-							"field": "Microsoft.SQL/servers/requestedServiceObjectiveId",
+							"field": "Microsoft.SQL/servers/databases/requestedServiceObjectiveId",
 							"in": "[parameters('listOfSKUId')]"
 						},
 						{
-							"field": "Microsoft.SQL/servers/requestedServiceObjectiveName",
+							"field": "Microsoft.SQL/servers/databases/requestedServiceObjectiveName",
 							"in": "[parameters('listOfSKUName')]"
 						}
 					]


### PR DESCRIPTION


Instead of "Microsoft.SQL/servers/requestedServiceObjectiveId" should be replaced in both cases by "Microsoft.SQL/servers/databases/requestedServiceObjectiveName"

See Aliases section on https://docs.microsoft.com/en-us/azure/azure-policy/policy-definition