### PR TITLE
Fixing broken links and examples

### DIFF
--- a/1-contribution-guide/README.md
+++ b/1-contribution-guide/README.md
@@ -3,7 +3,7 @@
 This repository contains all currently available Azure Policy samples contributed by the community. The following information is relevant to get started with contributing to this repository.
 
 - [**Contribution guide**](/1-contribution-guide/README.md#contribution-guide). Describes the minimal guidelines for contributing.
-- [**Git tutorial**](/1-contribution-guide/git-tutorial.md#git-tutorial). Step by step to get you started with Git.
+- [**Git tutorial**](https://guides.github.com/activities/hello-world/). Step by step to get you started with Git.
 - [**Useful Tools**](/1-contribution-guide/useful-tools.md#useful-tools). Useful resources and tools for Azure development.
 
 ## Create Policy Definitions and Assignments
@@ -46,6 +46,6 @@ The README.md describes your policy. A good description helps other community me
 - *Optional: Prerequisites
 - *Optional: Notes
 
-Example README: [Approved VM images - README](../samples/compute/allowed-custom-images/README.md)
+Example README: [Approved VM images - README](../samples/Compute/allowed-custom-images/README.md)
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/samples/General/audit-allowed-locations/README.md
+++ b/samples/General/audit-allowed-locations/README.md
@@ -30,8 +30,8 @@ $assignment
 
 ````cli
 
-az policy definition create --name 'audit-location-deployments' --display-name 'Audit for allowed locations' --description 'This policy enables you to audit the locations where your resources have been deployed. Use this to understand what is within your environment and if it matches company guidelines.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Location/audit-allowed-locations/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Location/audit-allowed-locations/azurepolicy.parameters.json' --mode Indexed
+az policy definition create --name 'audit-location-deployments' --display-name 'Audit for allowed locations' --description 'This policy enables you to audit the locations where your resources have been deployed. Use this to understand what is within your environment and if it matches company guidelines.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/General/audit-allowed-locations/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/General/audit-allowed-locations/azurepolicy.parameters.json' --mode Indexed
 
-az policy assignment create --name <assignmentname> --scope <scope> --policy "audit-location-deployments" --params '{"listOfAllowedLocations":{'value': [ 'ukwest', 'eastus']}}'
+az policy assignment create --name <assignmentname> --scope <scope> --policy "audit-location-deployments" --params "{'listOfAllowedLocations':{'value': [ 'ukwest', 'eastus']}}"
 
 ````


### PR DESCRIPTION
**Contribution Guide:**
- Git tutorial: the linked file doesn't exist in this repo. Linking to Github Guides instead
- Example README: compute=>Compute (link had incorrect casing)

**audit-allowed-locations CLI examples**:
- fix path: Location => General
- wrap params in double quotes
