### PR TITLE
Corrected storageAccountId output

### DIFF
--- a/samples/Monitoring/apply-diagnostic-setting-network-security-group/azurepolicy.json
+++ b/samples/Monitoring/apply-diagnostic-setting-network-security-group/azurepolicy.json
@@ -142,7 +142,7 @@
                                     "outputs": {
                                        "storageAccountId": {
                                           "type": "string",
-                                          "value": "[resourceId('Microsoft.Storage/storageAccounts',concat(parameters('storagePrefix'), parameters('location')))]"
+                                          "value": "[resourceId(parameters('rgName'),'Microsoft.Storage/storageAccounts',concat(parameters('storagePrefix'), parameters('location')))]"
                                        }
                                     }
                                  }

--- a/samples/Monitoring/apply-diagnostic-setting-network-security-group/azurepolicy.rules.json
+++ b/samples/Monitoring/apply-diagnostic-setting-network-security-group/azurepolicy.rules.json
@@ -118,7 +118,7 @@
                               "outputs": {
                                  "storageAccountId": {
                                     "type": "string",
-                                    "value": "[resourceId('Microsoft.Storage/storageAccounts',concat(parameters('storagePrefix'), parameters('location')))]"
+                                    "value": "[resourceId(parameters('rgName'),'Microsoft.Storage/storageAccounts',concat(parameters('storagePrefix'), parameters('location')))]"
                                  }
                               }
                            }


### PR DESCRIPTION
Corrected storageAccountId output value to reference the correct resource group. Previously this woudl default to the resource group containing the NSG and will fail if the storage account does not exist in the same resource group as the NSG.