### PR TITLE
Fix "applicaiton" typo in sample and folder name - Part 1

### DIFF
--- a/samples/Network/application-gateway-skus/README.md
+++ b/samples/Network/application-gateway-skus/README.md
@@ -1,0 +1,28 @@
+# Allowed Application Gateway SKUs
+
+This policy enables you to specify a set of application Gateway SKUs that your organization can deploy.
+
+## Try on Portal
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-policy%2Fmaster%2Fsamples%2FNetwork%2Fapplicaiton-gateway-skus%2Fazurepolicy.json)
+
+## Try with PowerShell
+
+````powershell
+$definition = New-AzureRmPolicyDefinition -Name "applicaiton-gateway-skus" -DisplayName "Allowed Application Gateway SKUs" -description "This policy enables you to specify a set of application Gateway SKUs that your organization can deploy." -Policy 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/applicaiton-gateway-skus/azurepolicy.rules.json' -Parameter 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/applicaiton-gateway-skus/azurepolicy.parameters.json' -Mode All
+$definition
+$assignment = New-AzureRMPolicyAssignment -Name <assignmentname> -Scope <scope>  -listOfAllowedSKUs <Allowed SKUs> -PolicyDefinition $definition
+$assignment 
+````
+
+
+
+## Try with CLI
+
+````cli
+
+az policy definition create --name 'applicaiton-gateway-skus' --display-name 'Allowed Application Gateway SKUs' --description 'This policy enables you to specify a set of application Gateway SKUs that your organization can deploy.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/applicaiton-gateway-skus/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/applicaiton-gateway-skus/azurepolicy.parameters.json' --mode All
+
+az policy assignment create --name <assignmentname> --scope <scope> --policy "applicaiton-gateway-skus" 
+
+````

--- a/samples/Network/application-gateway-skus/README.md
+++ b/samples/Network/application-gateway-skus/README.md
@@ -4,7 +4,7 @@ This policy enables you to specify a set of application Gateway SKUs that your o
 
 ## Try on Portal
 
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-policy%2Fmaster%2Fsamples%2FNetwork%2Fapplicaiton-gateway-skus%2Fazurepolicy.json)
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-policy%2Fmaster%2Fsamples%2FNetwork%2Fapplication-gateway-skus%2Fazurepolicy.json)
 
 ## Try with PowerShell
 

--- a/samples/Network/application-gateway-skus/README.md
+++ b/samples/Network/application-gateway-skus/README.md
@@ -9,20 +9,16 @@ This policy enables you to specify a set of application Gateway SKUs that your o
 ## Try with PowerShell
 
 ````powershell
-$definition = New-AzureRmPolicyDefinition -Name "applicaiton-gateway-skus" -DisplayName "Allowed Application Gateway SKUs" -description "This policy enables you to specify a set of application Gateway SKUs that your organization can deploy." -Policy 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/applicaiton-gateway-skus/azurepolicy.rules.json' -Parameter 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/applicaiton-gateway-skus/azurepolicy.parameters.json' -Mode All
+$definition = New-AzureRmPolicyDefinition -Name "application-gateway-skus" -DisplayName "Allowed Application Gateway SKUs" -description "This policy enables you to specify a set of application Gateway SKUs that your organization can deploy." -Policy 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/application-gateway-skus/azurepolicy.rules.json' -Parameter 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/application-gateway-skus/azurepolicy.parameters.json' -Mode All
 $definition
 $assignment = New-AzureRMPolicyAssignment -Name <assignmentname> -Scope <scope>  -listOfAllowedSKUs <Allowed SKUs> -PolicyDefinition $definition
-$assignment 
+$assignment
 ````
-
-
 
 ## Try with CLI
 
 ````cli
+az policy definition create --name 'application-gateway-skus' --display-name 'Allowed Application Gateway SKUs' --description 'This policy enables you to specify a set of application Gateway SKUs that your organization can deploy.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/application-gateway-skus/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/application-gateway-skus/azurepolicy.parameters.json' --mode All
 
-az policy definition create --name 'applicaiton-gateway-skus' --display-name 'Allowed Application Gateway SKUs' --description 'This policy enables you to specify a set of application Gateway SKUs that your organization can deploy.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/applicaiton-gateway-skus/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/applicaiton-gateway-skus/azurepolicy.parameters.json' --mode All
-
-az policy assignment create --name <assignmentname> --scope <scope> --policy "applicaiton-gateway-skus" 
-
+az policy assignment create --name <assignmentname> --scope <scope> --policy "application-gateway-skus"
 ````

--- a/samples/Network/application-gateway-skus/azurepolicy.json
+++ b/samples/Network/application-gateway-skus/azurepolicy.json
@@ -1,0 +1,34 @@
+{
+    "properties": {
+        "displayName": "Allowed Application Gateway SKUs",
+        "description": "This policy enables you to specify a set of application Gateway SKUs that your organization can deploy.",
+        "parameters": {
+            "listOfAllowedSKUs": {
+                "type": "Array",
+                "metadata": {
+                    "description": "The list of SKUs that can be specified for application gateways.",
+                    "displayName": "Allowed SKUs"
+                }
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Network/applicationGateways"
+                    },
+                    {
+                        "not": {
+                            "field": "Microsoft.Network/applicationGateways/sku.name",
+                            "in": "[parameters('listOfAllowedSKUs')]"
+                        }
+                    }
+                ]
+            },
+            "then": {
+                "effect": "Deny"
+            }
+        }
+    }
+}

--- a/samples/Network/application-gateway-skus/azurepolicy.parameters.json
+++ b/samples/Network/application-gateway-skus/azurepolicy.parameters.json
@@ -1,0 +1,9 @@
+{
+	"listOfAllowedSKUs": {
+		"type": "Array",
+		"metadata": {
+			"description": "The list of SKUs that can be specified for application gateways.",
+			"displayName": "Allowed SKUs"
+		}
+	}
+}

--- a/samples/Network/application-gateway-skus/azurepolicy.rules.json
+++ b/samples/Network/application-gateway-skus/azurepolicy.rules.json
@@ -1,0 +1,19 @@
+{
+	"if": {
+		"allOf": [
+			{
+				"field": "type",
+				"equals": "Microsoft.Network/applicationGateways"
+			},
+			{
+				"not": {
+					"field": "Microsoft.Network/applicationGateways/sku.name",
+					"in": "[parameters('listOfAllowedSKUs')]"
+				}
+			}
+		]
+	},
+	"then": {
+		"effect": "Deny"
+	}
+}


### PR DESCRIPTION
This copies the existing folder with a typo to a new folder with the correct name.  This is multi-step to avoid breaking azure-docs builds.  Once the related sample on azure-docs is updated, another PR will delete the folder with the incorrect name.

Here's the link to the incoming PR that spotted the issue: MicrosoftDocs/azure-docs#22302