### PR TITLE
Audit Resource Locks on Resource Groups based on Tags

### DIFF
--- a/samples/ResourceGroup/audit-resourceGroup-resourceLocks/README.md
+++ b/samples/ResourceGroup/audit-resourceGroup-resourceLocks/README.md
@@ -1,0 +1,25 @@
+# Audit Resource Locks on Resource Groups based on Tags
+
+Audits all Resource Groups that have a specific Tag, for the CanNotDelete Resource Lock.
+Within this Policy, you sepcify the Tag Name and Tag Value that will be used for identifying the Resource Groups to audit.
+
+## Try in the Azure Portal
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-policy%2Fmaster%2Fsamples%2FResourceGroup%2Faudit-resourceGroup-resourceLocks%2Fazurepolicy.json)
+
+## Try with PowerShell
+
+````powershell
+$definition = New-AzureRmPolicyDefinition -Name "audit-resourceGroup-resourceLocks" -DisplayName "Audit Resource Locks on Resource Groups based on Tags" -description "Audits all Resource Groups that have a specific Tag, for the CanNotDelete Resource Lock." -Policy 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.rules.json' -Parameter 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.parameters.json' -Mode All
+$definition
+$assignment = New-AzureRMPolicyAssignment -Name <assignmentname> -Scope <scope> -tagName <tagName> -tagValue <tagValue> -PolicyDefinition $definition
+$assignment 
+````
+
+## Try with CLI
+
+````cli
+az policy definition create --name 'audit-resourceGroup-resourceLocks' --display-name 'Audit Resource Locks on Resource Groups based on Tags' --description 'Audits all Resource Groups that have a specific Tag, for the CanNotDelete Resource Lock.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.parameters.json' --mode All
+
+az policy assignment create --name <assignmentname> --scope <scope> --policy "audit-resourceGroup-resourceLocks" 
+````

--- a/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.json
+++ b/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.json
@@ -1,0 +1,47 @@
+{
+    "properties": {
+        "displayName": "Audit Resource Locks on Resource Groups based on Tags",
+        "description": "Audits all Resource Groups that have a specific Tag, for the CanNotDelete Resource Lock.",
+        "mode": "All",
+        "parameters": {
+            "tagName": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Tag Name",
+                "description": "The Tag namne to audit against (i.e. Environment, CostCenter, etc.)"
+              }
+            },
+            "tagValue": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Tag Value",
+                "description": "Value of the tag to audit against (i.e. Prod/UAT/TEST, 12345, etc.)"
+              }
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Resources/subscriptions/resourceGroups"
+                    },
+                    {
+                        "field": "[concat('tags[', parameters('tagName'), ']')]",
+                        "equals": "[parameters('tagValue')]"
+                    }
+                ]
+            },
+            "then": {
+                "effect": "auditIfNotExists",
+                "details": {
+                    "type": "Microsoft.Authorization/locks",
+                    "existenceCondition": {
+                        "field": "Microsoft.Authorization/locks/level",
+                        "equals": "CanNotDelete"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.parameters.json
+++ b/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.parameters.json
@@ -1,0 +1,16 @@
+{
+    "tagName": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Tag Name",
+        "description": "The tag namne to audit against (i.e. Environment, CostCenter, etc.)"
+      }
+    },
+    "tagValue": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Tag Value",
+        "description": "Value of the tag to audit against (i.e. Prod/UAT/TEST, 12345, etc.)"
+      }
+    }
+}

--- a/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.rules.json
+++ b/samples/ResourceGroup/audit-resourceGroup-resourceLocks/azurepolicy.rules.json
@@ -1,0 +1,24 @@
+{
+    "if": {
+        "allOf": [
+            {
+            "field": "type",
+            "equals": "Microsoft.Resources/subscriptions/resourceGroups"
+            },
+            {
+            "field": "[concat('tags[', parameters('tagName'), ']')]",
+            "equals": "[parameters('tagValue')]"
+            }
+        ]
+    },
+    "then": {
+        "effect": "auditIfNotExists",
+        "details": {
+            "type": "Microsoft.Authorization/locks",
+            "existenceCondition": {
+                "field": "Microsoft.Authorization/locks/level",
+                "equals": "CanNotDelete"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Audits all Resource Groups that have a specific Tag, for the CanNotDelete Resource Lock.