### PR TITLE
Parameterize copy-resourcegroup-tag to maximize reusability.

### DIFF
--- a/samples/ResourceGroup/copy-resourcegroup-tag/README.md
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/README.md
@@ -1,6 +1,6 @@
 # Copy resource group tag to resource
 
-Copy a specific tag from the resource group to the resource.  For example, a tag named *example* on the resource group will be copied to the resources.  Change the word *example* in the policy rule to change the name of the tag copied to a resource.
+Copy a tag specified in the parameter value from the resource group to the resource.  For example, a tag named costCenter on the resource group will be copied to the resources. Provide the actual tag name in tagName parameter at time of policy assignment.
 
 ## Try on Azure Portal
 
@@ -10,7 +10,7 @@ Copy a specific tag from the resource group to the resource.  For example, a tag
 
 ````powershell
 # Create the Policy Definition
-$definition = New-AzPolicyDefinition -Name "copy-resourcegroup-tag" -DisplayName "Copy resource group tag to resource" -description "Copy a specific tag from the resource group to the resource.  For example, a tag named example on the resource group will be copied to the resources.  Change the word example in the policy rule to change the name of the tag copied to a resource." -Policy 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json' -Mode Indexed
+$definition = New-AzPolicyDefinition -Name "copy-resourcegroup-tag" -DisplayName "Copy resource group tag to resource" -description "Copy a tag specified in the parameter value from the resource group to the resource.  For example, a tag named costCenter on the resource group will be copied to the resources. Provide the actual tag name in tagName parameter at time of policy assignment." -Policy 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json' -Mode Indexed
 
 # Show Definititon
 $definition
@@ -26,7 +26,7 @@ $assignment
 
 ````cli
 # Create the Policy Definition
-az policy definition create --name 'copy-resourcegroup-tag' --display-name 'Copy resource group tag to resource' --description 'Copy a specific tag from the resource group to the resource.  For example, a tag named example on the resource group will be copied to the resources.  Change the word example in the policy rule to change the name of the tag copied to a resource.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json' --mode Indexed
+az policy definition create --name 'copy-resourcegroup-tag' --display-name 'Copy resource group tag to resource' --description 'Copy a tag specified in the parameter value from the resource group to the resource.  For example, a tag named costCenter on the resource group will be copied to the resources. Provide the actual tag name in tagName parameter at time of policy assignment.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json' --mode Indexed
 
 # Create the Policy Assignment
 az policy assignment create --name <assignmentname> --scope <scope> --policy "copy-resourcegroup-tag" 

--- a/samples/ResourceGroup/copy-resourcegroup-tag/README.md
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/README.md
@@ -16,7 +16,8 @@ $definition = New-AzPolicyDefinition -Name "copy-resourcegroup-tag" -DisplayName
 $definition
 
 # Create the Policy Assignment
-$assignment = New-AzPolicyAssignment -Name <assignmentname> -Scope <scope> -PolicyDefinition $definition
+$scope = Get-AzResourceGroup -Name 'YourResourceGroup'
+$assignment = New-AzPolicyAssignment -Name "copy-resource-group-tag" -Scope $scope -PolicyDefinition $definition -tagName "CostCenter"
 
 # Show Assignment
 $assignment 
@@ -29,6 +30,6 @@ $assignment
 az policy definition create --name 'copy-resourcegroup-tag' --display-name 'Copy resource group tag to resource' --description 'Copy a tag specified in the parameter value from the resource group to the resource.  For example, a tag named costCenter on the resource group will be copied to the resources. Provide the actual tag name in tagName parameter at time of policy assignment.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json' --mode Indexed
 
 # Create the Policy Assignment
-az policy assignment create --name <assignmentname> --scope <scope> --policy "copy-resourcegroup-tag" 
+az policy assignment create --name 'copy-resourcegroup-tag' --scope <scope> --policy "copy-resourcegroup-tag" --params "{'tagName':{'value': 'costCenter'}}" 
 
 ````

--- a/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.json
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.json
@@ -13,14 +13,14 @@
         },
         "policyRule": {
             "if": {
-                "field": "[concat('tags.', parameters('tagName'))]",
+                "field": "[concat('tags[', parameters('tagName'), ']')]",
                 "exists": "false"
             },
             "then": {
                 "effect": "append",
                 "details": [
                     {
-                        "field": "[concat('tags.', parameters('tagName'))]",
+                        "field": "[concat('tags[', parameters('tagName'), ']')]",
                         "value": "[resourceGroup().tags[parameters('tagName')]]"
                     }
                 ]

--- a/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.json
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.json
@@ -2,18 +2,26 @@
     "properties": {
         "displayName": "Copy resource group tag to resource",
         "mode": "Indexed",
-        "description": "Copy a specific tag from the resource group to the resource.  For example, a tag named example on the resource group will be copied to the resources.  Change the word example in the policy rule to change the name of the tag copied to a resource.",
+        "description": "Copy a tag specified in the parameter value from the resource group to the resource.  For example, a tag named costCenter on the resource group will be copied to the resources.",
+        "parameters": {
+            "tagName": {
+                "type": "String",
+                "metadata": {
+                    "description": "Name of the tag, such as costCenter"
+                }
+            }
+        },
         "policyRule": {
             "if": {
-                "field": "tags.example",
+                "field": "[concat('tags.', parameters('tagName'))]",
                 "exists": "false"
             },
             "then": {
                 "effect": "append",
                 "details": [
                     {
-                        "field": "tags.example",
-                        "value": "[resourceGroup().tags.example]"
+                        "field": "[concat('tags.', parameters('tagName'))]",
+                        "value": "[resourceGroup().tags[parameters('tagName')]]"
                     }
                 ]
             }

--- a/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.parameters.json
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.parameters.json
@@ -1,8 +1,8 @@
 {
-	"tagName": {
-		"type": "String",
-		"metadata": {
-			"description": "Name of the tag, such as costCenter"
-		}
-	}
+    "tagName": {
+        "type": "String",
+        "metadata": {
+            "description": "Name of the tag, such as costCenter"
+        }
+    }
 }

--- a/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.parameters.json
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.parameters.json
@@ -1,1 +1,8 @@
-{}
+{
+	"tagName": {
+		"type": "String",
+		"metadata": {
+			"description": "Name of the tag, such as costCenter"
+		}
+	}
+}

--- a/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json
@@ -1,13 +1,13 @@
 {
     "if": {
-        "field": "[concat('tags.', parameters('tagName'))]",
+        "field": "[concat('tags[', parameters('tagName'), ']')]",
         "exists": "false"
     },
     "then": {
         "effect": "append",
         "details": [
             {
-                "field": "[concat('tags.', parameters('tagName'))]",
+                "field": "[concat('tags[', parameters('tagName'), ']')]",
                 "value": "[resourceGroup().tags[parameters('tagName')]]"
             }
         ]

--- a/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json
@@ -1,14 +1,14 @@
 {
     "if": {
-        "field": "tags.example",
+        "field": "[concat('tags.', parameters('tagName'))]",
         "exists": "false"
     },
     "then": {
         "effect": "append",
         "details": [
             {
-                "field": "tags.example",
-                "value": "[resourceGroup().tags.example]"
+                "field": "[concat('tags.', parameters('tagName'))]",
+                "value": "[resourceGroup().tags[parameters('tagName')]]"
             }
         ]
     }


### PR DESCRIPTION
Instead of hardcoding the tag name as example, it can be specified as a parameter so that the Policy definition can be rolled up into a larger initiative encompassing multiple tags to be copied down to resources.