### PR TITLE
Update copy-resourcegroup-tag README and policy rule to better match the built-in policy

### DIFF
--- a/samples/ResourceGroup/copy-resourcegroup-tag/README.md
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/README.md
@@ -1,7 +1,8 @@
 # Copy resource group tag to resource
 
-Copy a tag specified in the parameter value from the resource group to the resource.  For example, a tag named costCenter on the resource group will be copied to the resources. Provide the actual tag name in tagName parameter at time of policy assignment.
+When a resource which is missing the specified tag is created or updated, adds that tag with its value from the resource group to the resource. Does not modify the tags of resources created before this policy was applied until those resources are changed.
 
+ In the example below, the tag named costCenter on the resource group will be copied to the resources (when they are updated). Provide the tag name in tagName parameter at time of policy assignment.
 ## Try on Azure Portal
 
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-policy%2Fmaster%2Fsamples%2FResourceGroup%2Fcopy-resourcegroup-tag%2Fazurepolicy.json)

--- a/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.json
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.json
@@ -13,8 +13,20 @@
         },
         "policyRule": {
             "if": {
-                "field": "[concat('tags[', parameters('tagName'), ']')]",
-                "exists": "false"
+                "allOf": [
+                    {
+                        "field": "[concat('tags[', parameters('tagName'), ']')]",
+                        "exists": "false"
+                    },
+                    {
+                        "value": "[resourceGroup().tags[parameters('tagName')]]",
+                        "exists": "true"
+                    },
+                    {
+                        "value": "[resourceGroup().tags[parameters('tagName')]]",
+                        "notEquals": ""
+                    }
+                ]
             },
             "then": {
                 "effect": "append",

--- a/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json
+++ b/samples/ResourceGroup/copy-resourcegroup-tag/azurepolicy.rules.json
@@ -1,7 +1,19 @@
 {
     "if": {
-        "field": "[concat('tags[', parameters('tagName'), ']')]",
-        "exists": "false"
+        "allOf": [
+            {
+                "field": "[concat('tags[', parameters('tagName'), ']')]",
+                "exists": "false"
+            },
+            {
+                "value": "[resourceGroup().tags[parameters('tagName')]]",
+                "exists": "true"
+            },
+            {
+                "value": "[resourceGroup().tags[parameters('tagName')]]",
+                "notEquals": ""
+            }
+        ]
     },
     "then": {
         "effect": "append",


### PR DESCRIPTION
- Update the description so it's clear this does not apply to existing resources.
- Update policy rule to match the built-in policy.
