### PR TITLE
Update the policy to use nsg name instead of nsg id

### DIFF
--- a/samples/Network/enforce-nsg-on-subnet/README.md
+++ b/samples/Network/enforce-nsg-on-subnet/README.md
@@ -1,6 +1,8 @@
 # NSG X on every subnet
 
-This policy enforces a specific NSG on every subnet
+This policy enforces a specific NSG on every subnet.
+
+Since NSG is a regional resource, to enforce the policy at the subscription level across all regions, create one nsg with the same name on each region.
 
 ## Try on Portal
 
@@ -11,7 +13,7 @@ This policy enforces a specific NSG on every subnet
 ````powershell
 $definition = New-AzPolicyDefinition -Name "enforce-nsg-on-subnet" -DisplayName "NSG X on every subnet" -description "This policy enforces a specific NSG on every subnet" -Policy 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/enforce-nsg-on-subnet/azurepolicy.rules.json' -Parameter 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/enforce-nsg-on-subnet/azurepolicy.parameters.json' -Mode All
 $definition
-$assignment = New-AzPolicyAssignment -Name <assignmentname> -Scope <scope>  -nsgId <NSG Id> -PolicyDefinition $definition
+$assignment = New-AzPolicyAssignment -Name <assignmentname> -Scope <scope>  -nsgName <NSG Name> -PolicyDefinition $definition
 $assignment 
 ````
 

--- a/samples/Network/enforce-nsg-on-subnet/azurepolicy.json
+++ b/samples/Network/enforce-nsg-on-subnet/azurepolicy.json
@@ -6,11 +6,11 @@
         "description": "This policy enforces a specific NSG on every subnet",
         "mode": "All",
         "parameters": {
-            "nsgId": {
+            "nsgName": {
                 "type": "String",
                 "metadata": {
-                    "description": "Resource Id of the Network Security Group",
-                    "displayName": "NSG Id"
+                    "description": "Name of the Network Security Group",
+                    "displayName": "NSG Name"
                 }
             }
         },
@@ -26,7 +26,7 @@
                             {
                                 "not": {
                                     "field": "Microsoft.Network/virtualNetworks/subnets[*].networkSecurityGroup.id",
-                                    "equals": "[parameters('nsgId')]"
+                                    "equals": "[concat('/subscriptions/', subscription().subscriptionId, '/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Network/networkSecurityGroups/', parameters('nsgName'))]"
                                 }
                             }
                         ]
@@ -40,7 +40,7 @@
                             {
                                 "not": {
                                     "field": "Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id",
-                                    "equals": "[parameters('nsgId')]"
+                                    "equals": "[concat('/subscriptions/', subscription().subscriptionId, '/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Network/networkSecurityGroups/', parameters('nsgName'))]"
                                 }
                             }
                         ]

--- a/samples/Network/enforce-nsg-on-subnet/azurepolicy.parameters.json
+++ b/samples/Network/enforce-nsg-on-subnet/azurepolicy.parameters.json
@@ -1,9 +1,9 @@
 {
-	"nsgId": {
+	"nsgName": {
 		"type": "String",
 		"metadata": {
-			"description": "Resource Id of the Network Security Group",
-			"displayName": "NSG Id"
+			"description": "Name of the Network Security Group",
+			"displayName": "NSG Name"
 		}
 	}
 }

--- a/samples/Network/enforce-nsg-on-subnet/azurepolicy.rules.json
+++ b/samples/Network/enforce-nsg-on-subnet/azurepolicy.rules.json
@@ -10,7 +10,7 @@
 					{
 						"not": {
 							"field": "Microsoft.Network/virtualNetworks/subnets[*].networkSecurityGroup.id",
-							"equals": "[parameters('nsgId')]"
+							"equals": "[concat('/subscriptions/', subscription().subscriptionId, '/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Network/networkSecurityGroups/', parameters('nsgName'))]"
 						}
 					}
 				]
@@ -24,7 +24,7 @@
 					{
 						"not": {
 							"field": "Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id",
-							"equals": "[parameters('nsgId')]"
+							"equals": "[concat('/subscriptions/', subscription().subscriptionId, '/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Network/networkSecurityGroups/', parameters('nsgName'))]"
 						}
 					}
 				]


### PR DESCRIPTION
Current policy does not work cross region as nsg is a regional resource. To overcome that, use nsg name instead of nsg id. Users will need to create one nsg with same name in each region then apply the policy.