### PR TITLE
Add namespace exclusions to K8s OPA Gatekeeper artifacts

### DIFF
--- a/built-in-references/Kubernetes/container-allowed-images/constraint.yaml
+++ b/built-in-references/Kubernetes/container-allowed-images/constraint.yaml
@@ -4,12 +4,9 @@ metadata:
   name: container-allowed-images
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist
   parameters:
     imageRegex: {{ .Values.allowedContainerImagesRegex }}

--- a/built-in-references/Kubernetes/container-allowed-images/template.yaml
+++ b/built-in-references/Kubernetes/container-allowed-images/template.yaml
@@ -22,7 +22,6 @@ spec:
         package k8sazurecontainerallowedimages
 
         violation[{"msg": msg}] {
-          input.review.object.metadata.namespace != "kube-system"
           container := input_containers[_]
           not re_match(input.parameters.imageRegex, container.image)
           msg := sprintf("Container image %v for container %v has not been allowed.", [container.image, container.name])

--- a/built-in-references/Kubernetes/container-allowed-ports/constraint.yaml
+++ b/built-in-references/Kubernetes/container-allowed-ports/constraint.yaml
@@ -4,12 +4,9 @@ metadata:
   name: container-allowed-ports
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist
   parameters:
     allowedPorts: {{ .Values.allowedContainerPorts }}

--- a/built-in-references/Kubernetes/container-allowed-ports/template.yaml
+++ b/built-in-references/Kubernetes/container-allowed-ports/template.yaml
@@ -24,7 +24,6 @@ spec:
         package k8sazurecontainerallowedports
 
         violation[{"msg": msg}] {
-          input.review.object.metadata.namespace != "kube-system"
           container := input_containers[_]
           port := container.ports[_]
           format_int(port.containerPort, 10, portstr)

--- a/built-in-references/Kubernetes/container-no-privilege/constraint.yaml
+++ b/built-in-references/Kubernetes/container-no-privilege/constraint.yaml
@@ -1,14 +1,10 @@
-  
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sAzureContainerNoPrivilege
 metadata:
   name: container-no-privilege
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist

--- a/built-in-references/Kubernetes/container-no-privilege/template.yaml
+++ b/built-in-references/Kubernetes/container-no-privilege/template.yaml
@@ -16,7 +16,6 @@ spec:
         package k8sazurecontainernoprivilege
 
         violation[{"msg": msg, "details": {}}] {
-            input.review.object.metadata.namespace != "kube-system"
             c := input_containers[_]
             c.securityContext.privileged
             msg := sprintf("Privileged container is not allowed: %v, securityContext: %v", [c.name, c.securityContext])

--- a/built-in-references/Kubernetes/container-resource-limits/constraint.yaml
+++ b/built-in-references/Kubernetes/container-resource-limits/constraint.yaml
@@ -1,17 +1,13 @@
-  
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sAzureContainerLimits
 metadata:
   name: container-limits
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist
   parameters:
     cpuLimit : "{{ .Values.cpuLimit }}"
     memoryLimit: "{{ .Values.memoryLimit }}"

--- a/built-in-references/Kubernetes/container-resource-limits/template.yaml
+++ b/built-in-references/Kubernetes/container-resource-limits/template.yaml
@@ -142,12 +142,10 @@ spec:
         }
 
         violation[{"msg": msg}] {
-          input.review.object.metadata.namespace != "kube-system"
           general_violation[{"msg": msg, "field": "containers"}]
         }
 
         violation[{"msg": msg}] {
-          input.review.object.metadata.namespace != "kube-system"
           general_violation[{"msg": msg, "field": "initContainers"}]
         }
 

--- a/built-in-references/Kubernetes/ingress-hostnames-conflict/constraint.yaml
+++ b/built-in-references/Kubernetes/ingress-hostnames-conflict/constraint.yaml
@@ -4,10 +4,7 @@ metadata:
   name: ingress-hostnames-conflict
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: ["extensions", "networking.k8s.io"]
         kinds: ["Ingress"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist

--- a/built-in-references/Kubernetes/ingress-hostnames-conflict/template.yaml
+++ b/built-in-references/Kubernetes/ingress-hostnames-conflict/template.yaml
@@ -33,7 +33,6 @@ spec:
         }
 
         violation[{"msg": msg}] {
-          input.review.object.metadata.namespace != "kube-system"
           input.review.kind.kind == "Ingress"
           apiVersion := make_apiversion(input.review.kind)
           apis = ["extensions/v1beta1", "networking.k8s.io/v1beta1"]

--- a/built-in-references/Kubernetes/ingress-https-only/constraint.yaml
+++ b/built-in-references/Kubernetes/ingress-https-only/constraint.yaml
@@ -1,14 +1,10 @@
-  
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sAzureIngressHttpsOnly
 metadata:
   name: ingress-https-only
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: ["extensions", "networking.k8s.io"]
         kinds: ["Ingress"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist

--- a/built-in-references/Kubernetes/ingress-https-only/template.yaml
+++ b/built-in-references/Kubernetes/ingress-https-only/template.yaml
@@ -19,7 +19,6 @@ spec:
           input.review.kind.kind == "Ingress"
           re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)
           ingress = input.review.object
-          ingress.metadata.namespace != "kube-system"
           not https_complete(ingress)
           msg := sprintf("Ingress should be https. tls configuration and allow-http=false annotation are required for %v", [ingress.metadata.name])
         }

--- a/built-in-references/Kubernetes/load-balancer-no-public-ips/constraint.yaml
+++ b/built-in-references/Kubernetes/load-balancer-no-public-ips/constraint.yaml
@@ -4,10 +4,7 @@ metadata:
   name: load-balancer-no-public-ips
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: [""]
         kinds: ["Service"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist

--- a/built-in-references/Kubernetes/load-balancer-no-public-ips/template.yaml
+++ b/built-in-references/Kubernetes/load-balancer-no-public-ips/template.yaml
@@ -16,7 +16,6 @@ spec:
         package k8sazureloadbalancernopublicips
 
         violation[{"msg": msg}] {
-          input.review.object.metadata.namespace != "kube-system"
           not loadbalancer_no_pip(input.review.object)
           msg := sprintf("Load Balancers should not have public IPs. azure-load-balancer-internal annotation is required for %v", [input.review.object.metadata.name])
         }

--- a/built-in-references/Kubernetes/pod-enforce-labels/constraint.yaml
+++ b/built-in-references/Kubernetes/pod-enforce-labels/constraint.yaml
@@ -1,16 +1,12 @@
-  
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sAzurePodEnforceLabels
 metadata:
   name: pod-enforce-labels
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist
   parameters:
     labels: {{ .Values.labels }}

--- a/built-in-references/Kubernetes/pod-enforce-labels/template.yaml
+++ b/built-in-references/Kubernetes/pod-enforce-labels/template.yaml
@@ -24,7 +24,6 @@ spec:
         package k8sazurepodenforcelabels
 
         violation[{"msg": msg, "details": {"missing_labels": missing}}] {
-          input.review.object.metadata.namespace != "kube-system"
           required := {label | label := input.parameters.labels[_]}
           provided := {label | input.review.object.metadata.labels[label]}
           missing := required - provided

--- a/built-in-references/Kubernetes/service-allowed-ports/constraint.yaml
+++ b/built-in-references/Kubernetes/service-allowed-ports/constraint.yaml
@@ -4,12 +4,9 @@ metadata:
   name: service-allowed-ports
 spec:
   match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
     kinds:
       - apiGroups: [""]
         kinds: ["Service"]
-    namespaceSelector:
-      matchExpressions:
-      - key: control-plane
-        operator: DoesNotExist
   parameters:
     allowedPorts: {{ .Values.allowedServicePorts }}

--- a/built-in-references/Kubernetes/service-allowed-ports/template.yaml
+++ b/built-in-references/Kubernetes/service-allowed-ports/template.yaml
@@ -25,7 +25,6 @@ spec:
 
         violation[{"msg": msg}] {
           service := input.review.object
-          service.metadata.namespace != "kube-system"
           not service_is_kubernetes(service)
           port = service.spec.ports[_]
           format_int(port.port, 10, portstr)


### PR DESCRIPTION
1. Remove 'kube-system' namespace from templates as customer wants to audit and monitor unwanted deployments in kube-system namespace.
2. Add capability for namespace exclusions in constraints which enables customers to exclude K8s namespaces from policy evaluation and auditing.