### PR TITLE
Remove unnecessary gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,9 +129,6 @@ AutoTest.Net/
 # Web workbench (sass)
 .sass-cache/
 
-# Installshield output folder
-[Ee]xpress/
-
 # DocProject is a documentation generator add-in
 DocProject/buildhelp/
 DocProject/Help/*.HxT
@@ -212,7 +209,6 @@ Generated_Code/
 # to a newer Visual Studio version. Backup files are not needed,
 # because we have git ;-)
 _UpgradeReport_Files/
-Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 


### PR DESCRIPTION
Over-aggressive .gitignore was causing some built-in policydefinitions to not be published since their category name was an "ignored" directory