### PR TITLE
Update AppService_FunctionApp_Audit_java_Latest.json

### DIFF
--- a/built-in-policies/policyDefinitions/App Service/AppService_FunctionApp_Audit_java_Latest.json
+++ b/built-in-policies/policyDefinitions/App Service/AppService_FunctionApp_Audit_java_Latest.json
@@ -82,7 +82,7 @@
                   },
                   {
                     "field": "Microsoft.Web/sites/config/web.javaVersion",
-                    "like": "[concat(parameters('JavaLatestVersion'), '*')]"
+                    "like": "[concat('*', parameters('JavaLatestVersion'))]"
                   }
                 ]
               }


### PR DESCRIPTION
Field `Microsoft.Web/sites/config/web.javaVersion` outputs java version as `1.x` where `x` is the Java version used. The current concat adds an asterisk at the end of the statement and thus does not match the output. Confirmed in our subscriptions moving the asterisk to the beginning of the match allows the policy to correctly identify Java version for function apps.