### PR TITLE
Corrected metadata descriptions on KeyVault_DeployDiagnosticLog_Deploy_LogAnalytics.json

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/KeyVault_DeployDiagnosticLog_Deploy_LogAnalytics.json
+++ b/built-in-policies/policyDefinitions/Monitoring/KeyVault_DeployDiagnosticLog_Deploy_LogAnalytics.json
@@ -47,7 +47,7 @@
         ],
         "metadata": {
           "displayName": "Enable metrics",
-          "description": "Whether to enable metrics stream to the Event Hub - True or False"
+          "description": "Whether to enable metrics stream to the Log Analytics workspace - True or False"
         }
       },
       "logsEnabled": {
@@ -59,7 +59,7 @@
         ],
         "metadata": {
           "displayName": "Enable logs",
-          "description": "Whether to enable logs stream to the Event Hub  - True or False"
+          "description": "Whether to enable logs stream to the Log Analytics workspace - True or False"
         }
       }
     },


### PR DESCRIPTION
Corrected metadata descriptions from "Event Hub" to "Log Analytics workspace" for the metricsEnabled and logsEnabled parameters.