### PR TITLE
Cosmos DB | Add PS1 to get RP aliases so that both Azure CLI and PS1 …

### DIFF
--- a/samples/CosmosDB/audit-cosmosdb-throughput/Get-Aliases.ps1
+++ b/samples/CosmosDB/audit-cosmosdb-throughput/Get-Aliases.ps1
@@ -1,0 +1,1 @@
+Get-AzPolicyAlias -NamespaceMatch “documentdb” | select namespace, resourcetype -ExpandProperty aliases


### PR DESCRIPTION
Add sample PS1 script to show how to get Cosmos DB RP aliases to use in creating custom policy definition rules. This is to add to the already-provided Azure CLI approach in get-aliases.sh.