### PR TITLE
limit https traffic check to older api-versions

### DIFF
--- a/samples/Storage/https-traffic-only/azurepolicy.json
+++ b/samples/Storage/https-traffic-only/azurepolicy.json
@@ -12,10 +12,24 @@
                         "equals": "Microsoft.Storage/storageAccounts"
                     },
                     {
-                        "not": {
-                            "field": "Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly",
-                            "equals": "true"
-                        }
+                        "anyOf": [
+                            {
+                                "allOf": [
+                                    {
+                                        "value": "[requestContext().apiVersion]",
+                                        "less": "2019-04-01"
+                                    },
+                                    {
+                                        "field": "Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly",
+                                        "exists": "false"
+                                    }
+                                ]
+                            },
+                            {
+                                "field": "Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly",
+                                "equals": "false"
+                            }
+                        ]
                     }
                 ]
             },

--- a/samples/Storage/https-traffic-only/azurepolicy.rules.json
+++ b/samples/Storage/https-traffic-only/azurepolicy.rules.json
@@ -1,19 +1,33 @@
 {
-	"if": {
-		"allOf": [
-			{
-				"field": "type",
-				"equals": "Microsoft.Storage/storageAccounts"
-			},
-			{
-				"not": {
-					"field": "Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly",
-					"equals": "true"
-				}
-			}
-		]
-	},
-	"then": {
-		"effect": "deny"
-	}
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Storage/storageAccounts"
+            },
+            {
+                "anyOf": [
+                    {
+                        "allOf": [
+                            {
+                                "value": "[requestContext().apiVersion]",
+                                "less": "2019-04-01"
+                            },
+                            {
+                                "field": "Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly",
+                                "exists": "false"
+                            }
+                        ]
+                    },
+                    {
+                        "field": "Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly",
+                        "equals": "false"
+                    }
+                ]
+            }
+        ]
+    },
+    "then": {
+        "effect": "deny"
+    }
 }


### PR DESCRIPTION
Since API version 2019-04-01 supportsHttpsTrafficOnly defaults to true and  the property doesn't have to be included in the PUT request anymore , therefore we should only check requests using an older API Version