### PR TITLE
added built-in policy for VMSS sku's

### DIFF
--- a/built-in-policies/policyDefinitions/Compute/VMSSSkusAllowed_Deny.json
+++ b/built-in-policies/policyDefinitions/Compute/VMSSSkusAllowed_Deny.json
@@ -1,0 +1,46 @@
+{
+    "properties": {
+       "displayName": "Allowed virtual machine size SKUs for Virtual Machine Scale Sets",
+       "policyType": "BuiltIn",
+       "mode": "Indexed",
+       "description": "This policy enables you to specify a set of virtual machine size SKUs for Virtual Machine Scale Sets that your organization can deploy.",
+       "metadata": {
+          "version": "1.0.0",
+          "category": "Compute"
+       },
+       "parameters": {
+          "listOfAllowedSKUs": {
+             "type": "Array",
+             "metadata": {
+                "description": "The list of size SKUs that can be specified for virtual machines.",
+                "displayName": "Allowed Size SKUs",
+                "strongType": "VMSKUs"
+             }
+          }
+       },
+       "policyRule": {
+            "if": {
+                "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Compute/virtualMachineScaleSets"
+                },
+                {
+                    "not": {
+                    "field": "Microsoft.Compute/VirtualMachineScaleSets/sku.name",
+                    "in": "[parameters('listOfAllowedSKUs')]"
+                    }
+                }
+                ]
+            },
+            "then": {
+                "effect": "deny"
+            }
+       }
+    },
+    "id": "/providers/Microsoft.Authorization/policyDefinitions/a7032590-9c5d-4450-bee6-c5a7f0100542",
+    "name": "a7032590-9c5d-4450-bee6-c5a7f0100542"
+ }
+
+
+


### PR DESCRIPTION
The built-in policy for VM SKU's to be allowed does not include VMSS. Customers could work around the VM SKU policy by deploying a VMSS with a single VM using any SKU. This policy corrects that behavior if also applied. 