### PR TITLE
Create domain join with a tags with an Azure policy

### DIFF
--- a/samples/Compute/domain join with tags
+++ b/samples/Compute/domain join with tags
@@ -1,0 +1,142 @@
+{
+    "Name": "Custom - company - IaaS - Insim domain join for windows VMs",
+    "ResourceName": "name",
+    "ResourceType": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+      "displayName": "Custom - company - IaaS - Insim domain join for windows VMs",
+      "metadata": {
+        "category": "Virtual Machines"
+      },
+      "policyType": "Custom",
+      "mode": "Indexed",
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Compute/virtualMachines"
+            },
+            {
+              "field": "Microsoft.Compute/virtualMachines/osProfile.windowsConfiguration.provisionVMAgent",
+              "exists": "true"
+            },
+            {
+              "field": "tags['domainjoin']",
+              "exists": "true"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+            ],
+            "existenceCondition": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                  "equals": "JsonADDomainExtension"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                  "equals": "Microsoft.Compute"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/provisioningState",
+                  "equals": "Succeeded"
+                }
+              ]
+            },
+            "deployment": {
+              "properties": {
+                "mode": "incremental",
+                "template": {
+                  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "vmName": {
+                      "type": "string"
+                    },
+                    "domain-user": {
+                      "type": "string"
+                    },
+                    "domain-password": {
+                      "type": "string"
+                    }
+                  },
+                  "variables": {},
+                  "resources": [
+                    {
+                      "apiVersion": "2015-06-15",
+                      "type": "Microsoft.Compute/virtualMachines/extensions",
+                      "name": "[concat(parameters('vmName'),'/joindomain')]",
+                      "location": "[resourceGroup().location]",
+                      "properties": {
+                        "publisher": "Microsoft.Compute",
+                        "type": "JsonADDomainExtension",
+                        "typeHandlerVersion": "1.3",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                          "Name": "insim.biz",
+                          "OUPath": "OU=APP Servers,OU=Production,OU=Servers,DC=Test,DC=LOCAL",
+                          "User": "[concat('test.local', '\\', parameters('domain-user'))]",
+                          "Restart": "false",
+                          "Options": "3"
+                        },
+                        "protectedSettings": {
+                          "Password": "[parameters('domain-password')]"
+                        }
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "policy": {
+                      "type": "string",
+                      "value": "[concat('Enabled extension for VM', ': ', parameters('vmName'))]"
+                    }
+                  }
+                },
+                "parameters": {
+                  "vmName": {
+                    "value": "[field('name')]"
+                  },
+                  "domain-user": {
+                    "reference": {
+                      "keyVault": {
+                        "id": "/subscriptions/xxxxxxx-d263-3345-xxxx-ar33a55d4bd34/resourceGroups/test/providers/Microsoft.KeyVault/vaults/keyvaultiaas"
+                      },
+                      "secretName": "test-domain-join-user"
+                    }
+                  },
+                  "domain-password": {
+                    "reference": {
+                        "keyVault": {
+                            "id": "/subscriptions/xxxxxxx-d263-3345-xxxx-ar33a55d4bd34/resourceGroups/test/providers/Microsoft.KeyVault/vaults/keyvaultiaas"
+                        },
+                        "secretName": "test-domain-join-password"
+                    }
+                }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": [
+            "deployIfNotExists",
+            "auditIfNotExists"
+          ],
+          "defaultValue": "auditIfNotExists"
+        }
+      }
+    }
+  }


### PR DESCRIPTION
Domain join only with a tag done by an Azure policy. You only need an Azure keyvault for domain userid and password with domain join rights.