### PR TITLE
add namespaceSelector to PSP related Kubernetes Azure Policies

### DIFF
--- a/built-in-policies/policyDefinitions/Kubernetes/AllowedHostPaths.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/AllowedHostPaths.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "allowedHostPaths": {
         "type": "Object",
         "metadata": {
@@ -81,7 +129,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/allowed-host-paths/constraint.yaml",
           "values": {
             "allowedHostPaths": "[parameters('allowedHostPaths').paths]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/AllowedProcMountType.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/AllowedProcMountType.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "procMountType": {
         "type": "String",
         "metadata": {
@@ -60,7 +108,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/allowed-proc-mount-types/constraint.yaml",
           "values": {
             "procMount": "[parameters('procMountType')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/AllowedSeccompProfile.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/AllowedSeccompProfile.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "allowedProfiles": {
         "type": "Array",
         "metadata": {
@@ -56,7 +104,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/allowed-seccomp-profiles/constraint.yaml",
           "values": {
             "allowedProfiles": "[parameters('allowedProfiles')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/AllowedUsersGroups.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/AllowedUsersGroups.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "runAsUserRule": {
         "type": "String",
         "metadata": {
@@ -247,7 +295,8 @@
               "rule": "[parameters('fsGroupRule')]",
               "ranges": "[parameters('fsGroupRanges').ranges]"
             },
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/AllowedVolumeTypes.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/AllowedVolumeTypes.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "allowedVolumeTypes": {
         "type": "Array",
         "metadata": {
@@ -56,7 +104,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/allowed-volume-types/constraint.yaml",
           "values": {
             "volumes": "[parameters('allowedVolumeTypes')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/BlockHostNamespace.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/BlockHostNamespace.json
@@ -30,6 +30,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -47,7 +95,8 @@
           "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/block-host-namespace/template.yaml",
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/block-host-namespace/constraint.yaml",
           "values": {
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerAllowedCapabilities.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerAllowedCapabilities.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "allowedCapabilities": {
         "type": "Array",
         "metadata": {
@@ -65,7 +113,8 @@
           "values": {
             "allowedCapabilities": "[parameters('allowedCapabilities')]",
             "requiredDropCapabilities": "[parameters('requiredDropCapabilities')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerAllowedImages.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerAllowedImages.json
@@ -37,6 +37,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -55,7 +103,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-allowed-images/constraint.yaml",
           "values": {
             "allowedContainerImagesRegex": "[parameters('allowedContainerImagesRegex')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerAllowedPorts.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerAllowedPorts.json
@@ -37,6 +37,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -55,7 +103,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-allowed-ports/constraint.yaml",
           "values": {
             "allowedContainerPorts": "[parameters('allowedContainerPortsList')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerNoPrivilege.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerNoPrivilege.json
@@ -30,6 +30,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -47,7 +95,8 @@
           "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-no-privilege/template.yaml",
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-no-privilege/constraint.yaml",
           "values": {
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerNoPrivilegeEscalation.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerNoPrivilegeEscalation.json
@@ -30,6 +30,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -47,7 +95,8 @@
           "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-no-privilege-escalation/template.yaml",
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-no-privilege-escalation/constraint.yaml",
           "values": {
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerResourceLimits.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerResourceLimits.json
@@ -44,6 +44,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -63,7 +111,8 @@
           "values": {
             "cpuLimit": "[parameters('cpuLimit')]",
             "memoryLimit": "[parameters('memoryLimit')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/EnforceAppArmorProfile.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/EnforceAppArmorProfile.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "allowedProfiles": {
         "type": "Array",
         "metadata": {
@@ -56,7 +104,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/enforce-apparmor-profile/constraint.yaml",
           "values": {
             "allowedProfiles": "[parameters('allowedProfiles')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/FlexVolumeDrivers.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/FlexVolumeDrivers.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "allowedFlexVolumeDrivers": {
         "type": "Array",
         "metadata": {
@@ -56,7 +104,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/flexvolume-drivers/constraint.yaml",
           "values": {
             "allowedFlexVolumeDrivers": "[parameters('allowedFlexVolumeDrivers')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/ForbiddenSysctlInterfaces.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ForbiddenSysctlInterfaces.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "forbiddenSysctls": {
         "type": "Array",
         "metadata": {
@@ -55,7 +103,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/forbidden-sysctl-interfaces/constraint.yaml",
           "values": {
             "forbiddenSysctls": "[parameters('forbiddenSysctls')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/HostNetworkPorts.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/HostNetworkPorts.json
@@ -31,6 +31,54 @@
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
       },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
+      },
       "allowHostNetwork": {
         "type": "Boolean",
         "metadata": {
@@ -74,7 +122,8 @@
             "allowHostNetwork": "[parameters('allowHostNetwork')]",
             "minPort": "[parameters('minPort')]",
             "maxPort": "[parameters('maxPort')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/IngressHostnamesConflict.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/IngressHostnamesConflict.json
@@ -30,6 +30,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -46,7 +94,8 @@
           "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/ingress-hostnames-conflict/template.yaml",
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/ingress-hostnames-conflict/constraint.yaml",
           "values": {
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/IngressHttpsOnly.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/IngressHttpsOnly.json
@@ -30,6 +30,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -47,7 +95,8 @@
           "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/ingress-https-only/template.yaml",
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/ingress-https-only/constraint.yaml",
           "values": {
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/LoadbalancerNoPublicIPs.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/LoadbalancerNoPublicIPs.json
@@ -30,6 +30,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -47,7 +95,8 @@
           "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/load-balancer-no-public-ips/template.yaml",
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/load-balancer-no-public-ips/constraint.yaml",
           "values": {
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/PodEnforceLabels.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/PodEnforceLabels.json
@@ -37,6 +37,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -55,7 +103,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/pod-enforce-labels/constraint.yaml",
           "values": {
             "labels": "[parameters('labelsList')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/ReadOnlyRootFileSystem.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ReadOnlyRootFileSystem.json
@@ -30,6 +30,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -47,7 +95,8 @@
           "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/read-only-root-filesystem/template.yaml",
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/read-only-root-filesystem/constraint.yaml",
           "values": {
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-policies/policyDefinitions/Kubernetes/SELinux.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/SELinux.json
@@ -35,6 +35,54 @@
                     "azure-arc"
                 ]
             },
+            "namespaceSelector": {
+              "type": "Object",
+              "metadata": {
+                "displayName": "Namespace selector",
+                "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+                "schema": {
+                  "type": "Object",
+                  "properties": {
+                    "matchExpressions": {
+                      "type": "Array",
+                      "items": {
+                        "type": "Object",
+                        "properties": {
+                          "key": {
+                            "type": "String"
+                          },
+                          "operator": {
+                            "type": "String",
+                            "allowedValues": [
+                              "In",
+                              "NotIn",
+                              "Exists",
+                              "DoesNotExist"
+                            ]
+                          },
+                          "values": {
+                            "type": "Array",
+                            "items": {
+                              "type": "String"
+                            }
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "matchExpressions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "defaultValue": {}
+            },
             "allowedSELinuxOptions": {
                 "type": "Object",
                 "metadata": {
@@ -92,7 +140,8 @@
                     "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/selinux/constraint.yaml",
                     "values": {
                         "excludedNamespaces": "[parameters('excludedNamespaces')]",
-                        "allowedSELinuxOptions": "[parameters('allowedSELinuxOptions').options]"
+                        "allowedSELinuxOptions": "[parameters('allowedSELinuxOptions').options]",
+                        "namespaceSelector": "[parameters('namespaceSelector')]"
                     }
                 }
             }

--- a/built-in-policies/policyDefinitions/Kubernetes/ServiceAllowedPorts.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ServiceAllowedPorts.json
@@ -37,6 +37,54 @@
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
         },
         "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      },
+      "namespaceSelector": {
+        "type": "Object",
+        "metadata": {
+          "displayName": "Namespace selector",
+          "description": "Standard Kubernetes namespace selector to include matching namespaces for policy evaluation.",
+          "schema": {
+            "type": "Object",
+            "properties": {
+              "matchExpressions": {
+                "type": "Array",
+                "items": {
+                  "type": "Object",
+                  "properties": {
+                    "key": {
+                      "type": "String"
+                    },
+                    "operator": {
+                      "type": "String",
+                      "allowedValues": [
+                        "In",
+                        "NotIn",
+                        "Exists",
+                        "DoesNotExist"
+                      ]
+                    },
+                    "values": {
+                      "type": "Array",
+                      "items": {
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "matchExpressions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "defaultValue": {}
       }
     },
     "policyRule": {
@@ -55,7 +103,8 @@
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/service-allowed-ports/constraint.yaml",
           "values": {
             "allowedServicePorts": "[parameters('allowedServicePortsList')]",
-            "excludedNamespaces": "[parameters('excludedNamespaces')]"
+            "excludedNamespaces": "[parameters('excludedNamespaces')]",
+            "namespaceSelector": "[parameters('namespaceSelector')]"
           }
         }
       }

--- a/built-in-references/Kubernetes/allowed-host-paths/constraint.yaml
+++ b/built-in-references/Kubernetes/allowed-host-paths/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/allowed-proc-mount-types/constraint.yaml
+++ b/built-in-references/Kubernetes/allowed-proc-mount-types/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/allowed-seccomp-profiles/constraint.yaml
+++ b/built-in-references/Kubernetes/allowed-seccomp-profiles/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/allowed-users-groups/constraint.yaml
+++ b/built-in-references/Kubernetes/allowed-users-groups/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/allowed-volume-types/constraint.yaml
+++ b/built-in-references/Kubernetes/allowed-volume-types/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/block-host-namespace/constraint.yaml
+++ b/built-in-references/Kubernetes/block-host-namespace/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/container-allowed-capabilities/constraint.yaml
+++ b/built-in-references/Kubernetes/container-allowed-capabilities/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/container-allowed-images/constraint.yaml
+++ b/built-in-references/Kubernetes/container-allowed-images/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/container-allowed-ports/constraint.yaml
+++ b/built-in-references/Kubernetes/container-allowed-ports/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/container-no-privilege-escalation/constraint.yaml
+++ b/built-in-references/Kubernetes/container-no-privilege-escalation/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/container-no-privilege/constraint.yaml
+++ b/built-in-references/Kubernetes/container-no-privilege/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/container-resource-limits/constraint.yaml
+++ b/built-in-references/Kubernetes/container-resource-limits/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/enforce-apparmor-profile/constraint.yaml
+++ b/built-in-references/Kubernetes/enforce-apparmor-profile/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/flexvolume-drivers/constraint.yaml
+++ b/built-in-references/Kubernetes/flexvolume-drivers/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/forbidden-sysctl-interfaces/constraint.yaml
+++ b/built-in-references/Kubernetes/forbidden-sysctl-interfaces/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/host-network-ports/constraint.yaml
+++ b/built-in-references/Kubernetes/host-network-ports/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/ingress-hostnames-conflict/constraint.yaml
+++ b/built-in-references/Kubernetes/ingress-hostnames-conflict/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: ["extensions", "networking.k8s.io"]
         kinds: ["Ingress"]

--- a/built-in-references/Kubernetes/ingress-https-only/constraint.yaml
+++ b/built-in-references/Kubernetes/ingress-https-only/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: ["extensions", "networking.k8s.io"]
         kinds: ["Ingress"]

--- a/built-in-references/Kubernetes/load-balancer-no-public-ips/constraint.yaml
+++ b/built-in-references/Kubernetes/load-balancer-no-public-ips/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Service"]

--- a/built-in-references/Kubernetes/pod-enforce-labels/constraint.yaml
+++ b/built-in-references/Kubernetes/pod-enforce-labels/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/read-only-root-filesystem/constraint.yaml
+++ b/built-in-references/Kubernetes/read-only-root-filesystem/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/selinux/constraint.yaml
+++ b/built-in-references/Kubernetes/selinux/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/built-in-references/Kubernetes/service-allowed-ports/constraint.yaml
+++ b/built-in-references/Kubernetes/service-allowed-ports/constraint.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}
+    namespaceSelector: {{ .Values.namespaceSelector }}
     kinds:
       - apiGroups: [""]
         kinds: ["Service"]


### PR DESCRIPTION
Its still in draft. I would appeciate if anyone can give a hint which gatekeeper helm chart is used for deployment to AKS so that it could be tuned to support this or anything else missed to enable this functionality.

Partialy fixes #619 