### PR TITLE
Safeguard Kubernetes built-in-references using CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# This file defines the individuals or teams that are responsible for code in this repository.
+# Each line is a file pattern followed by one or more owners.
+# Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# below owners will be requested for review when someone opens a pull request.
+*       @pilor @robga
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies files in built-in-references folder, only below owners and not the global
+# owner(s) will be requested for a review.
+/built-in-references/    @RamyasreeChakka @EmandM @sw47 @Amirzadehm


### PR DESCRIPTION
Azure Policy for Kubernetes built-ins references the YAML files located in /built-in-references/ in this repo. Safeguarding the files by explicitly setting code owners.