### PR TITLE
Update ASC Audit DDoS Protection Policy to consider "NotApplicable" VNETs compliant

### DIFF
--- a/built-in-policies/policyDefinitions/Security Center/ASC_EnableDDoSProtection_Audit.json
+++ b/built-in-policies/policyDefinitions/Security Center/ASC_EnableDDoSProtection_Audit.json
@@ -35,7 +35,8 @@
           "existenceCondition": {
             "field": "Microsoft.Security/assessments/status.code",
             "in": [
-              "Healthy"
+              "Healthy",
+              "NotApplicable"
             ]
           }
         }


### PR DESCRIPTION
Just a quick update to the policy that is evaluating the DDoS protection on a VNET. Currently, this policy will evaluate a VNET that has DDoS protection enabled, but no Application Gateway/Public IP associate, as non-compliant.

ASC's assessment results in a "NotApplicable" status code for this scenario. It does not show up as a recommendation in ASC, but is still marked non-compliant in the Azure Policy compliance view.

This PR appends "NotApplicable" to the list of compliant values so the resource shows as compliant in the Azure Policy compliance view.

Related issue: #643 