### PR TITLE
New Kubernetes policy: required liveness/ readiness probes policy

### DIFF
--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerProbesRequired.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerProbesRequired.json
@@ -1,0 +1,74 @@
+{
+  "properties": {
+    "displayName": "Ensure all pods have readiness or liveness probes configured",
+    "policyType": "BuiltIn",
+    "mode": "Microsoft.Kubernetes.Data",
+    "description": "This policy enforces that all pods have a readiness and/or liveness probes configured. This policy is generally available for Kubernetes Service (AKS), and preview for AKS Engine and Azure Arc enabled Kubernetes. For instructions on using this policy, visit https://aka.ms/kubepolicydoc.",
+    "metadata": {
+      "version": "1.0.1",
+      "category": "Kubernetes"
+    },
+    "parameters": {
+      "requiredProbesList": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Required probes list",
+          "description": "The list of probes readinessProbe and/or livenessProbe required for each pod."
+        },
+        "defaultValue": ["readinessProbe", "livenessProbe"]
+      },
+      "supportedProbeTypesList": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Supported probe types list",
+          "description": "The list of supported probe types can be any of tcpSocket, httpGet or exec."
+        },
+        "defaultValue": ["tcpSocket", "httpGet", "exec"]
+      },
+      "effect": {
+        "type": "String",
+        "defaultValue": "deny",
+        "allowedValues": [
+          "audit",
+          "deny",
+          "disabled"
+        ],
+        "metadata": {
+          "displayName": "Effect",
+          "description": "'Audit' allows a non-compliant resource to be created, but flags it as non-compliant. 'Deny' blocks the resource creation. 'Disable' turns off the policy."
+        }
+      },
+      "excludedNamespaces": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Namespace exclusions",
+          "description": "List of Kubernetes namespaces to exclude from policy evaluation."
+        },
+        "defaultValue": ["kube-system", "gatekeeper-system", "azure-arc"]
+      }
+    },
+    "policyRule": {
+      "if": {
+        "field": "type",
+        "in": [
+          "AKS Engine",
+          "Microsoft.Kubernetes/connectedClusters",
+          "Microsoft.ContainerService/managedClusters"
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-probes-required/template.yaml",
+          "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-probes-required/constraint.yaml",
+          "values": {
+            "requiredProbes": "[parameters('requiredProbesList')]",
+            "supportedProbeTypes": "[parameters('supportedProbeTypesList')]"
+          }
+        }
+      }
+    }
+  },
+  "id": "/providers/Microsoft.Authorization/policyDefinitions/3617414e-aa3a-4e84-9a47-bf61b7f23de0",
+  "name": "3617414e-aa3a-4e84-9a47-bf61b7f23de0"
+}

--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerProbesRequired.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerProbesRequired.json
@@ -13,17 +13,9 @@
         "type": "Array",
         "metadata": {
           "displayName": "Required probes list",
-          "description": "The list of probes readinessProbe and/or livenessProbe required for each pod."
+          "description": "The list of probes that are required to be defined on a container. Kubernetes currently supports 'livenessProbe', 'readinessProbe', and 'startupProbe'."
         },
         "defaultValue": ["readinessProbe", "livenessProbe"]
-      },
-      "supportedProbeTypesList": {
-        "type": "Array",
-        "metadata": {
-          "displayName": "Supported probe types list",
-          "description": "The list of supported probe types can be any of tcpSocket, httpGet or exec."
-        },
-        "defaultValue": ["tcpSocket", "httpGet", "exec"]
       },
       "effect": {
         "type": "String",
@@ -62,8 +54,7 @@
           "constraintTemplate": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-probes-required/template.yaml",
           "constraint": "https://raw.githubusercontent.com/Azure/azure-policy/master/built-in-references/Kubernetes/container-probes-required/constraint.yaml",
           "values": {
-            "requiredProbes": "[parameters('requiredProbesList')]",
-            "supportedProbeTypes": "[parameters('supportedProbeTypesList')]"
+            "requiredProbes": "[parameters('requiredProbesList')]"
           }
         }
       }

--- a/built-in-references/Kubernetes/container-probes-required/constraint.yaml
+++ b/built-in-references/Kubernetes/container-probes-required/constraint.yaml
@@ -9,5 +9,4 @@ spec:
       - apiGroups: [""]
         kinds: ["Pod"]
   parameters:
-    probes : {{ .Values.requiredProbes }}
-    probeTypes: {{ .Values.supportedProbeTypes }}
+    requiredProbes : {{ .Values.requiredProbes }}

--- a/built-in-references/Kubernetes/container-probes-required/constraint.yaml
+++ b/built-in-references/Kubernetes/container-probes-required/constraint.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAzureContainerProbesRequired
+metadata:
+  name: container-probes-required
+spec:
+  match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    probes : {{ .Values.requiredProbes }}
+    probeTypes: {{ .Values.supportedProbeTypes }}

--- a/built-in-references/Kubernetes/container-probes-required/template.yaml
+++ b/built-in-references/Kubernetes/container-probes-required/template.yaml
@@ -1,0 +1,56 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sazurecontainerprobesrequired
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAzureContainerProbesRequired
+        listKind: K8sAzureContainerProbesRequiredList
+        plural: k8sazurecontainerprobesrequired
+        singular: k8sazurecontainerprobesrequired
+      validation:
+        openAPIV3Schema:
+          properties:
+            probes:
+              type: array
+              items:
+                type: string
+            probeTypes:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredprobes
+
+        probe_type_set = probe_types {
+          probe_types := {type | type := input.parameters.probeTypes[_]}
+        }
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.containers[_]
+          probe := input.parameters.probes[_]
+          probe_is_missing(container, probe)
+          msg := get_violation_message(container, input.review, probe)
+        }
+
+        probe_is_missing(ctr, probe) = true {
+          not ctr[probe]
+        }
+
+        probe_is_missing(ctr, probe) = true {
+          probe_field_empty(ctr, probe)
+        }
+
+        probe_field_empty(ctr, probe) = true {
+          probe_fields := {field | ctr[probe][field]}
+          diff_fields := probe_type_set - probe_fields
+          count(diff_fields) == count(probe_type_set)
+        }
+
+        get_violation_message(container, review, probe) = msg {
+          msg := sprintf("Container <%v> in your <%v> <%v> has no <%v>", [container.name, review.kind.kind, review.object.metadata.name, probe])
+        }

--- a/built-in-references/Kubernetes/container-probes-required/template.yaml
+++ b/built-in-references/Kubernetes/container-probes-required/template.yaml
@@ -7,17 +7,10 @@ spec:
     spec:
       names:
         kind: K8sAzureContainerProbesRequired
-        listKind: K8sAzureContainerProbesRequiredList
-        plural: k8sazurecontainerprobesrequired
-        singular: k8sazurecontainerprobesrequired
       validation:
         openAPIV3Schema:
           properties:
-            probes:
-              type: array
-              items:
-                type: string
-            probeTypes:
+            requiredProbes:
               type: array
               items:
                 type: string
@@ -27,12 +20,12 @@ spec:
         package k8srequiredprobes
 
         probe_type_set = probe_types {
-          probe_types := {type | type := input.parameters.probeTypes[_]}
+          probe_types := {type | type := ["tcpSocket", "httpGet", "exec"][_]}
         }
 
         violation[{"msg": msg}] {
           container := input.review.object.spec.containers[_]
-          probe := input.parameters.probes[_]
+          probe := input.parameters.requiredProbes[_]
           probe_is_missing(container, probe)
           msg := get_violation_message(container, input.review, probe)
         }
@@ -51,6 +44,10 @@ spec:
           count(diff_fields) == count(probe_type_set)
         }
 
+        has_field(object, field) = true {
+            object[field]
+        }
+
         get_violation_message(container, review, probe) = msg {
-          msg := sprintf("Container <%v> in your <%v> <%v> has no <%v>", [container.name, review.kind.kind, review.object.metadata.name, probe])
+          msg := sprintf("Container <%v> in your <%v> <%v> has no <%v>. Required probes: %v", [container.name, review.kind.kind, review.object.metadata.name, probe, input.parameters.requiredProbes])
         }


### PR DESCRIPTION
This policy will allow to define if liveness/ readiness probes are required in a pod deployment.