### PR TITLE
3 new policy YAML files to be referenced from 3 built in policies

### DIFF
--- a/built-in-references/Kubernetes/block-default-namespace/constraint.yaml
+++ b/built-in-references/Kubernetes/block-default-namespace/constraint.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAzureBlockDefault
+metadata:
+  name: block-default-namespace
+spec:
+  match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
+    kinds:
+      - apiGroups: [""]
+        kinds: ["ConfigMap", "Pod", "Secret", "Service", "ServiceAccount"]

--- a/built-in-references/Kubernetes/block-default-namespace/template.yaml
+++ b/built-in-references/Kubernetes/block-default-namespace/template.yaml
@@ -1,0 +1,27 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sazureblockdefault
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAzureBlockDefault
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sazureblockdefault
+
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          is_default_namespace(obj.metadata)
+          msg := sprintf("Usage of the default namespace is not allowed, name: %v, kind: %v", [obj.metadata.name, obj.kind])
+        }
+
+        is_default_namespace(metadata) {
+          not metadata.namespace
+        }
+
+        is_default_namespace(metadata) {
+          metadata.namespace == "default"
+        }

--- a/built-in-references/Kubernetes/container-disallowed-capabilities/constraint.yaml
+++ b/built-in-references/Kubernetes/container-disallowed-capabilities/constraint.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAzureDisallowedCapabilities
+metadata:
+  name: container-disallowed-capabilities
+spec:
+  match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    disallowedCapabilities: {{ .Values.disallowedCapabilities }}

--- a/built-in-references/Kubernetes/container-disallowed-capabilities/template.yaml
+++ b/built-in-references/Kubernetes/container-disallowed-capabilities/template.yaml
@@ -1,0 +1,54 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sazuredisallowedcapabilities
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAzureDisallowedCapabilities
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedCapabilities:
+              type: array
+              items:
+                type: string
+            requiredDropCapabilities:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sazureblockcapabilities
+
+        violation[{"msg": msg}] {
+          container := input_containers[_]
+          has_disallowed_capabilities(container)
+          msg := sprintf("container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "disallowedCapabilities", [])])
+        }
+
+        has_disallowed_capabilities(container) {
+          input.parameters.disallowedCapabilities[_] == container.securityContext.capabilities.add[_]
+        }
+        has_disallowed_capabilities(container) {
+          input.parameters.disallowedCapabilities[_] == "*"
+        }
+
+        get_default(obj, param, _default) = out {
+          out = obj[param]
+        }
+
+        get_default(obj, param, _default) = out {
+          not obj[param]
+          not obj[param] == false
+          out = _default
+        }
+        input_containers[c] {
+            c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+            c := input.review.object.spec.initContainers[_]
+        }

--- a/built-in-references/Kubernetes/container-disallowed-capabilities/template.yaml
+++ b/built-in-references/Kubernetes/container-disallowed-capabilities/template.yaml
@@ -11,18 +11,14 @@ spec:
         # Schema for the `parameters` field
         openAPIV3Schema:
           properties:
-            allowedCapabilities:
-              type: array
-              items:
-                type: string
-            requiredDropCapabilities:
+            disallowedCapabilities:
               type: array
               items:
                 type: string
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
-        package k8sazureblockcapabilities
+        package k8sazuredisallowedcapabilities
 
         violation[{"msg": msg}] {
           container := input_containers[_]

--- a/built-in-references/Kubernetes/use-named-serviceaccount/constraint.yaml
+++ b/built-in-references/Kubernetes/use-named-serviceaccount/constraint.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAzureNamedServiceAccount
+metadata:
+  name: azure-named-service-account
+spec:
+  match:
+    excludedNamespaces: {{ .Values.excludedNamespaces }}
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]

--- a/built-in-references/Kubernetes/use-named-serviceaccount/template.yaml
+++ b/built-in-references/Kubernetes/use-named-serviceaccount/template.yaml
@@ -1,0 +1,24 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sazurenamedserviceaccount
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAzureNamedServiceAccount
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sazurenamedserviceaccount
+
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          not valid_service_account(obj.spec)
+          msg := sprintf("A service account must be used with deployed resources: Automounting service account token is disallowed, pod: %v", [obj.metadata.name])
+        }
+
+        valid_service_account(spec) {
+          spec.serviceAccountName
+          spec.automountServiceAccountToken == false
+        }


### PR DESCRIPTION
These are taken from https://github.com/Azure/Community-Policy/tree/master/Policies/Kubernetes

1) Block Default Namespace
2) Container Disallowed Capabilities
3) Use Named Service Account