### PR TITLE
Update ServiceAccount Rego policy rego

### DIFF
--- a/built-in-references/Kubernetes/use-named-serviceaccount/constraint.yaml
+++ b/built-in-references/Kubernetes/use-named-serviceaccount/constraint.yaml
@@ -1,7 +1,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: K8sAzureNamedServiceAccount
+kind: K8sAzureBlockAutomountToken
 metadata:
-  name: azure-named-service-account
+  name: azure-block-automount
 spec:
   match:
     excludedNamespaces: {{ .Values.excludedNamespaces }}

--- a/built-in-references/Kubernetes/use-named-serviceaccount/template.yaml
+++ b/built-in-references/Kubernetes/use-named-serviceaccount/template.yaml
@@ -19,6 +19,5 @@ spec:
         }
 
         valid_service_account(spec) {
-          spec.serviceAccountName
           spec.automountServiceAccountToken == false
         }

--- a/built-in-references/Kubernetes/use-named-serviceaccount/template.yaml
+++ b/built-in-references/Kubernetes/use-named-serviceaccount/template.yaml
@@ -1,21 +1,21 @@
 apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
-  name: k8sazurenamedserviceaccount
+  name: k8sazureblockautomounttoken
 spec:
   crd:
     spec:
       names:
-        kind: K8sAzureNamedServiceAccount
+        kind: K8sAzureBlockAutomountToken
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
-        package k8sazurenamedserviceaccount
+        package k8sazureblockautomounttoken
 
         violation[{"msg": msg}] {
           obj := input.review.object
           not valid_service_account(obj.spec)
-          msg := sprintf("A service account must be used with deployed resources: Automounting service account token is disallowed, pod: %v", [obj.metadata.name])
+          msg := sprintf("Automounting service account token is disallowed, pod: %v", [obj.metadata.name])
         }
 
         valid_service_account(spec) {


### PR DESCRIPTION
Update service accountpolicy to remove check for default serviceAccount name which is not needed.

Updating the constraint/template names to reflect what policy rego is doing more. These change have parity to the same policy in community-repo: 

https://github.com/Azure/Community-Policy/tree/master/Policies/Kubernetes/use-named-serviceaccount