### PR TITLE
Update Kubernetes_PSPRestrictedStandard.json

### DIFF
--- a/built-in-policies/policySetDefinitions/Kubernetes/Kubernetes_PSPRestrictedStandard.json
+++ b/built-in-policies/policySetDefinitions/Kubernetes/Kubernetes_PSPRestrictedStandard.json
@@ -137,6 +137,7 @@
           },
           "allowedVolumeTypes": {
             "value": [
+              "csi",
               "configMap",
               "emptyDir",
               "projected",


### PR DESCRIPTION
CSI becomes a standard in k8s thus adding it as allowed volume type makes perfect sense.