### PR TITLE
Excluded Resource Groups from the Policy

### DIFF
--- a/built-in-policies/policyDefinitions/General/AllowedLocations_Deny.json
+++ b/built-in-policies/policyDefinitions/General/AllowedLocations_Deny.json
@@ -5,7 +5,7 @@
       "mode": "Indexed",
       "description": "This policy enables you to restrict the locations your organization can specify when deploying resources. Use to enforce your geo-compliance requirements. Excludes resource groups, Microsoft.AzureActiveDirectory/b2cDirectories, and resources that use the 'global' region.",
       "metadata": {
-         "version": "1.0.0",
+         "version": "1.0.1",
          "category": "General"
       },
       "parameters": {
@@ -32,6 +32,10 @@
                {
                   "field": "type",
                   "notEquals": "Microsoft.AzureActiveDirectory/b2cDirectories"
+               },
+               {
+                  "field": "type",
+                  "notEquals": : "Microsoft.Resources/resourceGroups"
                }
             ]
          },

--- a/built-in-policies/policyDefinitions/General/AllowedLocations_Deny.json
+++ b/built-in-policies/policyDefinitions/General/AllowedLocations_Deny.json
@@ -35,7 +35,7 @@
                },
                {
                   "field": "type",
-                  "notEquals": : "Microsoft.Resources/resourceGroups"
+                  "notEquals": "Microsoft.Resources/resourceGroups"
                }
             ]
          },


### PR DESCRIPTION
The documentation states that this policy should exclude resource groups. But in reality, this does not. 