### PR TITLE
Update DataConnectorsAzureKeyVault_PolicyAssignment.json

### DIFF
--- a/built-in-policies/policyDefinitions/Key Vault/DataConnectorsAzureKeyVault_PolicyAssignment.json
+++ b/built-in-policies/policyDefinitions/Key Vault/DataConnectorsAzureKeyVault_PolicyAssignment.json
@@ -168,10 +168,10 @@
                   "value": "[field('name')]"
                 },
                 "AuditEventEnabled": {
-                  "value": "[parameters('AllMetricsEnabled')]"
+                  "value": "[parameters('AuditEventEnabled')]"
                 },
                 "AllMetricsEnabled": {
-                  "value": "[parameters('AuditEventEnabled')]"
+                  "value": "[parameters('AllMetricsEnabled')]"
                 }
               }
             }


### PR DESCRIPTION
Line no 170 to 175, the parameters are replaced with each other which is resulting in wrong logs going to log analytics workspace.

"AuditEventEnabled": {
 "value": "[parameters('AllMetricsEnabled')]" <-----------------------This should be "value": "[parameters('AuditEventEnabled')]"
},
"AllMetricsEnabled": {
 "value": "[parameters('AuditEventEnabled')]"  <------------This should be  "value": "[parameters('AllMetricsEnabled')]"
}