### PR TITLE
Correct typo from Azure Front Door Services services to Azure Front D…

### DIFF
--- a/built-in-policies/policyDefinitions/Azure Government/Network/WAF_AFD_Enabled_Audit.json
+++ b/built-in-policies/policyDefinitions/Azure Government/Network/WAF_AFD_Enabled_Audit.json
@@ -1,6 +1,6 @@
 ﻿{
   "properties": {
-    "displayName": "Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+    "displayName": "Web Application Firewall (WAF) should be enabled for Azure Front Door service",
     "description": "Deploy Azure Web Application Firewall (WAF) in front of public facing web applications for additional inspection of incoming traffic. Web Application Firewall (WAF) provides centralized protection of your web applications from common exploits and vulnerabilities such as SQL injections, Cross-Site Scripting, local and remote file executions. You can also restrict access to your web applications by countries, IP address ranges, and other http(s) parameters via custom rules.",
     "policyType": "BuiltIn",
     "mode": "Indexed",

--- a/built-in-policies/policyDefinitions/Network/WAF_AFD_Enabled_Audit.json
+++ b/built-in-policies/policyDefinitions/Network/WAF_AFD_Enabled_Audit.json
@@ -1,6 +1,6 @@
 ﻿{
   "properties": {
-    "displayName": "Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+    "displayName": "Web Application Firewall (WAF) should be enabled for Azure Front Door service",
     "description": "Deploy Azure Web Application Firewall (WAF) in front of public facing web applications for additional inspection of incoming traffic. Web Application Firewall (WAF) provides centralized protection of your web applications from common exploits and vulnerabilities such as SQL injections, Cross-Site Scripting, local and remote file executions. You can also restrict access to your web applications by countries, IP address ranges, and other http(s) parameters via custom rules.",
     "policyType": "BuiltIn",
     "mode": "Indexed",

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/DOD_IL4_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/DOD_IL4_audit.json
@@ -2305,7 +2305,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/DOD_IL5_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/DOD_IL5_audit.json
@@ -2329,7 +2329,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/FedRAMP_H_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/FedRAMP_H_audit.json
@@ -2225,7 +2225,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/FedRAMP_M_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/FedRAMP_M_audit.json
@@ -1841,7 +1841,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/NIST80053_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/NIST80053_audit.json
@@ -3845,7 +3845,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/NIST_SP_800-53_R5.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/NIST_SP_800-53_R5.json
@@ -4422,7 +4422,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Azure Government/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Security Center/AzureSecurityCenter.json
@@ -2465,7 +2465,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "Deploy Azure Web Application Firewall (WAF) in front of public facing web applications for additional inspection of incoming traffic. Web Application Firewall (WAF) provides centralized protection of your web applications from common exploits and vulnerabilities such as SQL injections, Cross-Site Scripting, local and remote file executions. You can also restrict access to your web applications by countries, IP address ranges, and other http(s) parameters via custom rules."
         }
       },
@@ -3073,7 +3073,11 @@
       },
       "kubernetesClustersShouldBeAccessibleOnlyOverHTTPSExcludedNamespaces": {
         "type": "Array",
-        "defaultValue": [ "kube-system", "gatekeeper-system", "azure-arc" ],
+        "defaultValue": [
+          "kube-system",
+          "gatekeeper-system",
+          "azure-arc"
+        ],
         "metadata": {
           "displayName": "Namespace exclusions",
           "description": "List of Kubernetes namespaces to exclude from policy evaluation."
@@ -3155,7 +3159,10 @@
       },
       "aPIManagementServicesShouldUseAVirtualNetworkEvaluatedSkuNames": {
         "type": "Array",
-        "defaultValue": [ "Developer", "Premium" ],
+        "defaultValue": [
+          "Developer",
+          "Premium"
+        ],
         "allowedValues": [
           "Developer",
           "Basic",

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/FedRAMP_H_audit.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/FedRAMP_H_audit.json
@@ -2225,7 +2225,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/FedRAMP_M_audit.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/FedRAMP_M_audit.json
@@ -1841,7 +1841,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST80053_audit.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST80053_audit.json
@@ -3845,7 +3845,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST_SP_800-53_R5.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST_SP_800-53_R5.json
@@ -4422,7 +4422,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Effect for policy: Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
         }
       },

--- a/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
@@ -3342,7 +3342,7 @@
           "Disabled"
         ],
         "metadata": {
-          "displayName": "Web Application Firewall (WAF) should be enabled for Azure Front Door Service service",
+          "displayName": "Web Application Firewall (WAF) should be enabled for Azure Front Door service",
           "description": "Deploy Azure Web Application Firewall (WAF) in front of public facing web applications for additional inspection of incoming traffic. Web Application Firewall (WAF) provides centralized protection of your web applications from common exploits and vulnerabilities such as SQL injections, Cross-Site Scripting, local and remote file executions. You can also restrict access to your web applications by countries, IP address ranges, and other http(s) parameters via custom rules."
         }
       },


### PR DESCRIPTION
Azure policy definition had an extra "services" in the end. It was perhaps because Azure Front Door was earlier called Azure Front Door Services.

The renaming of service by Azure didn't update in Azure policy definitions.