### PR TITLE
Improve ACR (azurecr.io) example regex

### DIFF
--- a/built-in-policies/policyDefinitions/Azure Government/Kubernetes/ContainerAllowedImages.json
+++ b/built-in-policies/policyDefinitions/Azure Government/Kubernetes/ContainerAllowedImages.json
@@ -105,7 +105,7 @@
         "type": "String",
         "metadata": {
           "displayName": "Allowed container images regex",
-          "description": "The RegEx rule used to match allowed container images in a Kubernetes cluster. For example, to allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "The RegEx rule used to match allowed container images in a Kubernetes cluster. For example, to allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       }
     },

--- a/built-in-policies/policyDefinitions/Kubernetes service/ContainerAllowedImages_EnforceRegoPolicy.json
+++ b/built-in-policies/policyDefinitions/Kubernetes service/ContainerAllowedImages_EnforceRegoPolicy.json
@@ -14,7 +14,7 @@
         "type": "String",
         "metadata": {
           "displayName": "Allowed container images regex",
-          "description": "Regex representing container images allowed in Kubernetes cluster. E.g. Regex of azure container registry images is ^.+azurecr.io/.+$"
+          "description": "Regex representing container images allowed in Kubernetes cluster. E.g. Regex of azure container registry images is ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect": {

--- a/built-in-policies/policyDefinitions/Kubernetes/ContainerAllowedImages.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/ContainerAllowedImages.json
@@ -101,7 +101,7 @@
         "type": "String",
         "metadata": {
           "displayName": "Allowed container images regex",
-          "description": "The RegEx rule used to match allowed container images in a Kubernetes cluster. For example, to allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "The RegEx rule used to match allowed container images in a Kubernetes cluster. For example, to allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       }
     },

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/DOD_IL4_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/DOD_IL4_audit.json
@@ -1863,7 +1863,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/DOD_IL5_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/DOD_IL5_audit.json
@@ -1887,7 +1887,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/FedRAMP_H_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/FedRAMP_H_audit.json
@@ -1783,7 +1783,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/FedRAMP_M_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/FedRAMP_M_audit.json
@@ -1399,7 +1399,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/NIST80053_audit.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/NIST80053_audit.json
@@ -3403,7 +3403,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/NIST_SP_800-53_R5.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Regulatory Compliance/NIST_SP_800-53_R5.json
@@ -3980,7 +3980,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Azure Government/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Azure Government/Security Center/AzureSecurityCenter.json
@@ -2572,7 +2572,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images regex",
-          "description": "The RegEx rule used to match allowed container images in a Kubernetes cluster. For example, to allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "The RegEx rule used to match allowed container images in a Kubernetes cluster. For example, to allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "allowedContainerImagesNamespaceExclusion": {

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/FedRAMP_H_audit.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/FedRAMP_H_audit.json
@@ -1783,7 +1783,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/FedRAMP_M_audit.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/FedRAMP_M_audit.json
@@ -1399,7 +1399,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST80053_audit.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST80053_audit.json
@@ -3403,7 +3403,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST_SP_800-53_R5.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST_SP_800-53_R5.json
@@ -3980,7 +3980,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-95edb821-ddaf-4404-9732-666045e056b4": {

--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/asb_v2.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/asb_v2.json
@@ -2105,7 +2105,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images for Kubernetes clusters",
-          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "Regular expression used to match allowed container images in a Kubernetes cluster; Ex: allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect-febd0533-8e55-448f-b837-bd0e06f16469": {

--- a/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
@@ -2299,7 +2299,7 @@
         "defaultValue": "^(.+){0}$",
         "metadata": {
           "displayName": "Allowed container images regex",
-          "description": "The RegEx rule used to match allowed container images in a Kubernetes cluster. For example, to allow any Azure Container Registry image by matching partial path: ^.+azurecr.io/.+$"
+          "description": "The RegEx rule used to match allowed container images in a Kubernetes cluster. For example, to allow any Azure Container Registry image by matching partial path: ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "allowedContainerImagesNamespaceExclusion": {

--- a/built-in-references/KubernetesService/container-allowed-images/limited-preview/azurepolicy.json
+++ b/built-in-references/KubernetesService/container-allowed-images/limited-preview/azurepolicy.json
@@ -12,7 +12,7 @@
         "type": "String",
         "metadata": {
           "displayName": "Allowed container images regex",
-          "description": "Regex representing container images allowed in Kubernetes cluster. E.g. Regex of azure container registry images is ^.+azurecr.io/.+$"
+          "description": "Regex representing container images allowed in Kubernetes cluster. E.g. Regex of azure container registry images is ^[^/]+\.azurecr\.io\/.+$"
         }
       },
       "effect": {

--- a/built-in-references/KubernetesService/container-allowed-images/limited-preview/azurepolicy.parameters.json
+++ b/built-in-references/KubernetesService/container-allowed-images/limited-preview/azurepolicy.parameters.json
@@ -3,7 +3,7 @@
     "type": "String",
     "metadata": {
       "displayName": "Allowed container images regex",
-      "description": "Regex representing container images allowed in Kubernetes cluster. E.g. Regex of azure container registry images is ^.+azurecr.io/.+$"
+      "description": "Regex representing container images allowed in Kubernetes cluster. E.g. Regex of azure container registry images is ^[^/]+\.azurecr\.io\/.+$"
     }
   },
   "effect": {


### PR DESCRIPTION
The old version, `^.+azurecr.io/.+$`, has four problems:

  * Strings like `evil.com/contoso.azurecr.io/foo` match.
  * Strings like `evilazurecr.io/foo` match.
  * Strings like `contoso.azurecraio/foo` match.
  * "Unescaped forward slash. This may cause issues if copying/pasting
    this expression into code." — [RegExr](https://regexr.com)

The new version, `^[^/]+\.azurecr\.io\/.+$`, has four fixes, respectively:

  * A literal `/` is not allowed before `azurecr` (in the subdomain).
  * A literal `.` is required directly before `azurecr`.
  * A literal `.` is required between `azurecr` and `io`.
  * The `/` is escaped with a backslash.

Useful command for viewing this commit:

    git show --color-words=.