### PR TITLE
Deprecating policy

### DIFF
--- a/built-in-policies/policyDefinitions/Key Vault/AzureKeyVaultPrivateEndpointEnabled_Audit.json
+++ b/built-in-policies/policyDefinitions/Key Vault/AzureKeyVaultPrivateEndpointEnabled_Audit.json
@@ -1,11 +1,12 @@
 {
   "properties": {
+    deprecated": true,
     "displayName": "Private endpoint should be configured for Key Vault",
     "policyType": "BuiltIn",
     "mode": "Indexed",
-    "description": "Private link provides a way to connect Key Vault to your Azure resources without sending traffic over the public internet. Private link provides defense in depth protection against data exfiltration.",
+    "description": "Private link provides a way to connect Key Vault to your Azure resources without sending traffic over the public internet. Private link provides defense in depth protection against data exfiltration. This policy has been deprecated; customers should instead use 'Azure Key Vaults should use private link'.",
     "metadata": {
-      "version": "1.1.0-preview",
+      "version": "1.1.0-deprecated",
       "category": "Key Vault",
       "preview": true
     },


### PR DESCRIPTION
Deprecating  AzureKeyVaultPrivateEndpointEnabled_Audit in favor of AzureKeyVault_Should_Use_PrivateEndpoint_Audit.json, per the instructions at https://dev.azure.com/msazure/One/_wiki/wikis/One.wiki/87054/Style-Instructions-and-Requirements?anchor=deprecating-a-policy-definition