### PR TITLE
Adding Four New Azure Policies for Network Security Products (Firewall, WAF and Public IPs+DDoS)

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/Azure_Application_Gateways_should_have_diagnostic_logging_enabled.json
+++ b/built-in-policies/policyDefinitions/Monitoring/Azure_Application_Gateways_should_have_diagnostic_logging_enabled.json
@@ -1,0 +1,58 @@
+{
+ "properties": {
+  "displayName": "Azure Application Gateways should have diagnostic logging enabled",
+  "policyType": "BuiltIn",
+  "mode": "All",
+  "description": "Enable diagnostic logs for Azure Application Gateway (plus WAF) and stream to a Log Analytics workspace.  Get detailed visibility into inbound web traffic and actions taken to mitigate attacks.",
+  "metadata": {
+   "version": "1.0.0",
+   "category": "Monitoring"
+  },
+  "parameters": {
+    "effect": {
+     "type": "String",
+     "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+     "AuditIfNotExists",
+     "Deny",
+     "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+    }   
+  },
+  "policyRule": {
+   "if": {
+    "field": "type",
+    "equals": "Microsoft.Network/applicationGateways"
+   },
+   "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+     "type": "Microsoft.Insights/diagnosticSettings",
+     "existenceCondition": {
+      "allOf": [
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/logs.enabled",
+        "equals": "true"
+       },
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
+        "equals": "true"
+       },
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+        "exists": "true"
+       }
+      ]
+     }
+    }
+   }
+  }
+ },
+ "id": "/providers/Microsoft.Authorization/policyDefinitions/8a04f872-51e9-4313-97fb-fc1c3543011c",
+ "type": "Microsoft.Authorization/policyDefinitions",
+ "name": "8a04f872-51e9-4313-97fb-fc1c3543011c"
+}

--- a/built-in-policies/policyDefinitions/Monitoring/Azure_Front_Doors_should_have_diagnostic_logging_enabled.json
+++ b/built-in-policies/policyDefinitions/Monitoring/Azure_Front_Doors_should_have_diagnostic_logging_enabled.json
@@ -1,0 +1,58 @@
+{
+ "properties": {
+  "displayName": "Azure Front Door should have diagnostic logging enabled",
+  "policyType": "BuiltIn",
+  "mode": "All",
+  "description": "Enable diagnostic logs for Azure Front Door (plus WAF) and stream to a Log Analytics workspace.  Get detailed visibility into inbound web traffic and actions taken to mitigate attacks.",
+  "metadata": {
+   "version": "1.0.0",
+   "category": "Monitoring"
+  },
+  "parameters": {
+    "effect": {
+     "type": "String",
+     "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+     "AuditIfNotExists",
+     "Deny",
+     "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+    }      
+  },
+  "policyRule": {
+   "if": {
+    "field": "type",
+    "equals": "Microsoft.Network/frontdoors"
+   },
+   "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+     "type": "Microsoft.Insights/diagnosticSettings",
+     "existenceCondition": {
+      "allOf": [
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/logs.enabled",
+        "equals": "true"
+       },
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
+        "equals": "true"
+       },
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+        "exists": "true"
+       }
+      ]
+     }
+    }
+   }
+  }
+ },
+ "id": "/providers/Microsoft.Authorization/policyDefinitions/8a04f872-51e9-4313-97fb-fc1c35430fd8",
+ "type": "Microsoft.Authorization/policyDefinitions",
+ "name": "8a04f872-51e9-4313-97fb-fc1c35430fd8"
+}

--- a/built-in-policies/policyDefinitions/Monitoring/Public_IP_addresses_should_have_diagnostic_logging_enabled_for_Azure_DDoS_Protection_Standard.json
+++ b/built-in-policies/policyDefinitions/Monitoring/Public_IP_addresses_should_have_diagnostic_logging_enabled_for_Azure_DDoS_Protection_Standard.json
@@ -1,0 +1,58 @@
+{
+ "properties": {
+  "displayName": "Public IP addresses should have diagnostic logging enabled for Azure DDoS Protection Standard",
+  "policyType": "BuiltIn",
+  "mode": "All",
+  "description": "Enable resource logs for public IP addresses in diagnostic settings and stream to a Log Analytics workspace.  Get detailed visibility into attack traffic and actions taken to mitigate DDoS attacks via notifications, reports, and flow logs.",
+  "metadata": {
+   "version": "1.0.0",
+   "category": "Monitoring"
+  },
+  "parameters": {
+    "effect": {
+     "type": "String",
+     "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+     },
+     "allowedValues": [
+      "AuditIfNotExists",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+    }  
+  },
+  "policyRule": {
+   "if": {
+    "field": "type",
+    "equals": "Microsoft.Network/publicIPAddresses"
+   },
+   "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+     "type": "Microsoft.Insights/diagnosticSettings",
+     "existenceCondition": {
+      "allOf": [
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/logs.enabled",
+        "equals": "true"
+       },
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
+        "equals": "true"
+       },
+       {
+        "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+        "exists": "true"
+       }
+      ]
+     }
+    }
+   }
+  }
+ },
+ "id": "/providers/Microsoft.Authorization/policyDefinitions/b6020039-df36-46f3-980c-6f76edb98c1f",
+ "type": "Microsoft.Authorization/policyDefinitions",
+ "name": "b6020039-df36-46f3-980c-6f76edb98c1f"
+}

--- a/built-in-policies/policyDefinitions/Network/Virtual_Hubs_should_be_protected_with_Azure_Firewall.json
+++ b/built-in-policies/policyDefinitions/Network/Virtual_Hubs_should_be_protected_with_Azure_Firewall.json
@@ -1,0 +1,51 @@
+{
+ "properties": {
+  "displayName": "Virtual Hubs should be protected with Azure Firewall",
+  "policyType": "Custom",
+  "mode": "All",
+  "description": "Deploy an Azure Firewall to your Virtual Hubs to protect and granularly control internet egress and ingress traffic.",
+  "metadata": {
+   "version": "1.0.0",
+   "category": "Network"
+  },
+  "parameters": {
+   "effect": {
+    "type": "String",
+    "metadata": {
+     "displayName": "Effect",
+     "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+     "Audit",
+     "Deny",
+     "Disabled"
+    ],
+    "defaultValue": "Audit"
+   }
+  },
+  "policyRule": {
+   "if": {
+    "anyOf": [
+     {
+      "allOf": [
+       {
+        "field": "type",
+        "equals": "Microsoft.Network/virtualHubs"
+       },
+       {
+        "field": "Microsoft.Network/virtualHubs/azureFirewall",
+        "exists": "false"
+       }
+      ]
+     }
+    ]
+   },
+   "then": {
+    "effect": "[parameters('effect')]"
+   }
+  }
+ },
+ "id": "/providers/Microsoft.Authorization/policyDefinitions/72923a3a-e567-46d3-b3f9-ffb2462a1c3a",
+ "type": "Microsoft.Authorization/policyDefinitions",
+ "name": "72923a3a-e567-46d3-b3f9-ffb2462a1c3a"
+}


### PR DESCRIPTION
Adding four new Azure Policies.  1 Policy for **Azure Firewall falls in the Network category** while the **other 3** for Azure Application Gateway, Azure Front Door and Public IP addresses + DDoS **fall in the Monitoring category**.

1. Virtual_Hubs_should_be_protected_with_Azure_Firewall.json:  Find all Virtual Hubs and flag as non-compliant if AZFW is not deployed to it 
2. Azure_Application_Gateways_should_have_diagnostic_logging_enabled.json:  Find all AppGWs and flag as non-compliant if logs, metrics and workspace is not configured in diagnostic settings (includes WAF logs)
3. Azure_Front_Doors_should_have_diagnostic_logging_enabled.json:  Find all AFDs and flag as non-compliant if logs, metrics and workspace is not configured in diagnostic settings (includes WAF logs)
4. Public_IP_addresses_should_have_diagnostic_logging_enabled_for_Azure_DDoS_Protection_Standard.json:  Find all Public IPs and flag as non-compliant if logs, metrics and workspace is not configured in diagnostic settings