### PR TITLE
Ensure storage account has unique name

### DIFF
--- a/samples/built-in-policy/default-diagnostic-setting/azurepolicy.json
+++ b/samples/built-in-policy/default-diagnostic-setting/azurepolicy.json
@@ -113,11 +113,14 @@
                                           "type": "string"
                                        }
                                     },
+                                    "variables": {
+                                       "storageAccountName": "[concat(substring(concat(parameters('storageprefix'), uniqueString(subscription().id)),0,sub(24,length(parameters('location')))), parameters('location'))]"
+                                     },
                                     "resources": [
                                        {
                                           "apiVersion": "2017-06-01",
                                           "type": "Microsoft.Storage/storageAccounts",
-                                          "name": "[concat(parameters('storageprefix'), parameters('location'))]",
+                                          "name": "[[variables('storageAccountName')]",
                                           "sku": {
                                              "name": "Standard_LRS",
                                              "tier": "Standard"
@@ -142,7 +145,7 @@
                                     "outputs": {
                                        "storageAccountId": {
                                           "type": "string",
-                                          "value": "[resourceId(parameters('rgName'), 'Microsoft.Storage/storageAccounts', concat(parameters('storagePrefix'), parameters('location')))]"
+                                          "value": "[[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
                                        }
                                     }
                                  }

--- a/samples/built-in-policy/default-diagnostic-setting/azurepolicy.rules.json
+++ b/samples/built-in-policy/default-diagnostic-setting/azurepolicy.rules.json
@@ -91,11 +91,14 @@
                                     "type": "string"
                                  }
                               },
+                              "variables": {
+                                 "storageAccountName": "[concat(substring(concat(parameters('storageprefix'), uniqueString(subscription().id)),0,sub(24,length(parameters('location')))), parameters('location'))]"
+                               },
                               "resources": [
                                  {
                                     "apiVersion": "2017-06-01",
                                     "type": "Microsoft.Storage/storageAccounts",
-                                    "name": "[concat(parameters('storageprefix'), parameters('location'))]",
+                                    "name": "[[variables('storageAccountName')]",
                                     "sku": {
                                        "name": "Standard_LRS",
                                        "tier": "Standard"
@@ -120,7 +123,7 @@
                               "outputs": {
                                  "storageAccountId": {
                                     "type": "string",
-                                    "value": "[resourceId(parameters('rgName'), 'Microsoft.Storage/storageAccounts', concat(parameters('storagePrefix'), parameters('location')))]"
+                                    "value": "[[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
                                  }
                               }
                            }


### PR DESCRIPTION
This policy doesn't work when it's assigned to a management group with multiple subscriptions.  The storage account name is based on two parameters: `storageprefix` and `location`.  When assigned to a management group, the `storageprefix` is set to a single value that affects all subscriptions in it.  Given that there could be 2 subscriptions in the same management group which NSGs in the same location, the policy only succeeds on the first subscription.

All subsequent subscriptions will fail because the storage account name is no longer available.

To make the storage account globally unique, I've added a uniqueString() based on subscription id and ensured that the generated storage account name is within 24 characters.

Highlighted text is from the uniqueString():

![image](https://user-images.githubusercontent.com/16688027/142694778-ad72a7c2-7173-46f0-9486-7799edcbbf75.png)
