### PR TITLE
add norwayeast to policyrule location array

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Windows_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Windows_Deploy.json
@@ -63,6 +63,7 @@
               "koreacentral",
               "northcentralus",
               "northeurope",
+              "norwayeast",
               "southafricanorth",
               "southcentralus",
               "southeastasia",


### PR DESCRIPTION
Add allowed location `norwayeast` in `Configure Windows machines to be associated with a Data Collection Rule` policy.