### PR TITLE
Typo "Azure database for MariaDB"→"Azure Database for MariaDB"

### DIFF
--- a/built-in-policies/policyDefinitions/SQL/DeployAtpOnMariaDbServers_Deploy.json
+++ b/built-in-policies/policyDefinitions/SQL/DeployAtpOnMariaDbServers_Deploy.json
@@ -1,9 +1,9 @@
 {
   "properties": {
-    "displayName": "Configure Advanced Threat Protection to be enabled on Azure database for MariaDB servers",
+    "displayName": "Configure Advanced Threat Protection to be enabled on Azure Database for MariaDB servers",
     "policyType": "BuiltIn",
     "mode": "Indexed",
-    "description": "Enable Advanced Threat Protection on your non-Basic tier Azure database for MariaDB servers to detect anomalous activities indicating unusual and potentially harmful attempts to access or exploit databases.",
+    "description": "Enable Advanced Threat Protection on your non-Basic tier Azure Database for MariaDB servers to detect anomalous activities indicating unusual and potentially harmful attempts to access or exploit databases.",
     "metadata": {
       "version": "1.0.0",
       "category": "SQL"


### PR DESCRIPTION
https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/SQL/DeployAtpOnMariaDbServers_Deploy.json
#PingMSFTDocs