### PR TITLE
Update ASC_All_Internet_traffic_should_be_routed_via_Azure_Firewall.json

### DIFF
--- a/built-in-policies/policyDefinitions/Network/ASC_All_Internet_traffic_should_be_routed_via_Azure_Firewall.json
+++ b/built-in-policies/policyDefinitions/Network/ASC_All_Internet_traffic_should_be_routed_via_Azure_Firewall.json
@@ -43,7 +43,7 @@
                         "equals": false
                       }
                     },
-                    "greaterOrEquals": 2
+                    "greaterOrEquals": 1
                   },
                   {
                     "field": "Microsoft.Network/virtualNetworks/subnets[*].routeTable",


### PR DESCRIPTION
AzureFirewall only has 1 IP Configuration in the subnet, even though there are 2 VMSS on the backend:
{
                "name": "AzureFirewallSubnet",
                "id": "/subscriptions/7cd632a4-113f-463e-87ee-e2855fbfd89f/resourceGroups/policytesting/providers/Microsoft.Network/virtualNetworks/Policy-DISC-VNET/subnets/AzureFirewallSubnet",
                "etag": "W/\"5e4237e2-5c86-4944-8164-5c8b43569b19\"",
                "properties": {
                    "provisioningState": "Succeeded",
                    "addressPrefix": "10.1.2.0/24",
                    "ipConfigurations": [
                        {
                            "id": "/subscriptions/7cd632a4-113f-463e-87ee-e2855fbfd89f/resourceGroups/PolicyTesting/providers/Microsoft.Network/azureFirewalls/rorieke-fw-disc/azureFirewallIpConfigurations/ip"
                        }
                    ]
                },
                "type": "Microsoft.Network/virtualNetworks/subnets"
            }

Ron.Rieke@microsoft.com