### PR TITLE
Remove Deny as a supported effect

### DIFF
--- a/built-in-policies/policyDefinitions/Machine Learning/Workspace_PrivateEndpoint_Audit.json
+++ b/built-in-policies/policyDefinitions/Machine Learning/Workspace_PrivateEndpoint_Audit.json
@@ -17,7 +17,6 @@
         },
         "allowedValues": [
           "Audit",
-          "Deny",
           "Disabled"
         ],
         "defaultValue": "Audit"


### PR DESCRIPTION
Because private endpoint connection can only occur after the private endpoint has been created, and because the private endpoint must be created after the workspace has been created, it isn't possible to meet the condition evaluated by this policy rule upon for a newly created workspace.

It seems the sensible thing to do is stop supporting Deny effect like other services with equivalent policies do.

Whether the corresponding documentation article https://github.com/MicrosoftDocs/azure-docs/blob/main/includes/policy/reference/bycat/policies-machine-learning.md is automatically maintained or a PR must also be created to update the docs accordingly, I don't know.

Should the docs be maintained manually, let me know and I can create that PR as well.

Thanks,
Nacho