### PR TITLE
Fix collision of Private DNS Zones of CosmosDB and Azure Synapse

### DIFF
--- a/built-in-policies/policyDefinitions/Cosmos DB/Cosmos_PrivateDNSZone_DeployIfNotExists.json
+++ b/built-in-policies/policyDefinitions/Cosmos DB/Cosmos_PrivateDNSZone_DeployIfNotExists.json
@@ -61,10 +61,6 @@
               }
             },
             "greaterOrEquals": 1
-          },
-          {
-              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
-              "contains": "Microsoft.DocumentDB"
           }
         ]
       },

--- a/built-in-policies/policyDefinitions/Cosmos DB/Cosmos_PrivateDNSZone_DeployIfNotExists.json
+++ b/built-in-policies/policyDefinitions/Cosmos DB/Cosmos_PrivateDNSZone_DeployIfNotExists.json
@@ -46,13 +46,25 @@
           },
           {
             "count": {
-              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
               "where": {
-                "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
-                "equals": "[parameters('privateEndpointGroupId')]"
+                "allOf": [
+                  {
+                    "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                    "contains": "Microsoft.DocumentDB"
+                  },
+                  {
+                    "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                    "equals": "account"
+                  }
+                ]
               }
             },
             "greaterOrEquals": 1
+          },
+          {
+              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+              "contains": "Microsoft.DocumentDB"
           }
         ]
       },

--- a/built-in-policies/policyDefinitions/Synapse/SynapseWorkspaceUsePrivateDnsZones_DeployIfNotExists.json
+++ b/built-in-policies/policyDefinitions/Synapse/SynapseWorkspaceUsePrivateDnsZones_DeployIfNotExists.json
@@ -52,10 +52,18 @@
           },
           {
             "count": {
-              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
               "where": {
-                "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
-                "equals": "[parameters('targetSubResource')]"
+                "allOf": [
+                  {
+                    "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                    "contains": "Microsoft.Synapse"
+                  },
+                  {
+                    "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                    "equals": "account"
+                  }
+                ]
               }
             },
             "greaterOrEquals": 1


### PR DESCRIPTION
The Private DNS Zone Policies of CosmosDB and Azure Synapse collide with each other.
When assigned the policy of Cosmos DB will hijack Priave Endpoints of Synapse and vice versa.

This PR adds checks to make sure the policies only are applied to the correct private endpoint serviceid