### PR TITLE
Fix grammar in ASC_EnableMFAForWritePermissions_Audit.json

### DIFF
--- a/built-in-policies/policyDefinitions/Security Center/ASC_EnableMFAForWritePermissions_Audit.json
+++ b/built-in-policies/policyDefinitions/Security Center/ASC_EnableMFAForWritePermissions_Audit.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "displayName": "MFA should be enabled accounts with write permissions on your subscription",
+    "displayName": "MFA should be enabled on accounts with write permissions on your subscription",
     "policyType": "BuiltIn",
     "mode": "All",
     "description": "Multi-Factor Authentication (MFA) should be enabled for all subscription accounts with write privileges to prevent a breach of accounts or resources.",


### PR DESCRIPTION
I found this missing word today when I was reviewing some of our Initiatives... 

This make this Policy consistent with the other two MFA Policies