### PR TITLE
Update NIST_SP_800-171_R2.json

### DIFF
--- a/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST_SP_800-171_R2.json
+++ b/built-in-policies/policySetDefinitions/Regulatory Compliance/NIST_SP_800-171_R2.json
@@ -464,6 +464,7 @@
       },
       "membersToExcludeInLocalAdministratorsGroup": {
         "type": "String",
+        "defaultValue": "",
         "metadata": {
           "displayName": "List of users that should be excluded from Windows virtual machines' Administrators group",
           "description": "A semicolon-separated list of users  that should be excluded in the Administrators local group. Ex: Administrator; myUser1; myUser2"
@@ -471,6 +472,7 @@
       },
       "membersToIncludeInLocalAdministratorsGroup": {
         "type": "String",
+        "defaultValue": "",
         "metadata": {
           "displayName": "List of users that should be included in Windows virtual machines' Administrators group",
           "description": "A semicolon-separated list of users that should be included in the Administrators local group; Ex: Administrator; myUser1; myUser2"
@@ -486,6 +488,7 @@
       },
       "logAnalyticsWorkspaceIDForVMAgents": {
         "type": "String",
+        "defaultValue": "",
         "metadata": {
           "displayName": "Log Analytics workspace ID for virtual machine agent reporting",
           "description": "ID (GUID) of the Log Analytics workspace where virtual machine agents should report"


### PR DESCRIPTION
Default values missing for three parameters ("membersToExcludeInLocalAdministratorsGroup", "membersToIncludeInLocalAdministratorsGroup", and "logAnalyticsWorkspaceIDForVMAgents") cause policy validation to fail when assigning the initiative.  Other NIST initiatives with similar parameters have a default value of "" set - for example, NIST SP 800-53 Rev. 4 version 17.0.0 lines 4779, 4843, and 4851 (https://github.com/Azure/azure-policy/blob/master/built-in-policies/policySetDefinitions/Regulatory%20Compliance/NIST_SP_800-53_R4.json).

![image](https://user-images.githubusercontent.com/25780196/202795843-4a009af8-3c4a-4980-87a2-f12e9cf11e56.png)
