### PR TITLE
Enable use of Wildcard in param

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_Deploy.json
@@ -80,8 +80,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfWindowsImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [


### PR DESCRIPTION
Without the change, if you use custom images, you need to add the image id of every custom image version. For each new image version, you need to update the policy assignment. This is an extra administration step and can easily be forgotten. 

With the change you can use wildcards in the parameter 'listOfWindowsImageIdToInclude' and define which version (or all) of you custom images you want to use:  E.g.:
[
"/subscriptions/<subscriptionId>/resourceGroups/YourResourceGroup/providers/Microsoft.Compute/images/ContosoStdImage/*" ]
to include all Image Versions of the ContosoStdImage