### PR TITLE
Wildcard for listOfWindowsImageIdToInclude Param 

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VMSS_Audit.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VMSS_Audit.json
@@ -84,8 +84,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfLinuxImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VMSS_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VMSS_Deploy.json
@@ -88,8 +88,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfLinuxImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VMSS_UAI_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VMSS_UAI_Deploy.json
@@ -111,8 +111,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfLinuxImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VM_Audit.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VM_Audit.json
@@ -84,8 +84,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfLinuxImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VM_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VM_Deploy.json
@@ -88,8 +88,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfLinuxImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VM_UAI_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_VM_UAI_Deploy.json
@@ -111,8 +111,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfLinuxImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VMSS_Audit.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VMSS_Audit.json
@@ -80,8 +80,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfWindowsImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VMSS_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VMSS_Deploy.json
@@ -80,8 +80,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfWindowsImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VMSS_UAI_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VMSS_UAI_Deploy.json
@@ -107,8 +107,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfWindowsImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_Audit.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_Audit.json
@@ -87,6 +87,8 @@
                     "field": "Microsoft.Compute/imageId",
                     "like": "[current('pattern')]"
                   }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_Audit.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_Audit.json
@@ -80,8 +80,13 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfWindowsImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_Deploy.json
@@ -80,8 +80,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfWindowsImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_UAI_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_VM_UAI_Deploy.json
@@ -107,8 +107,15 @@
           {
             "anyOf": [
               {
-                "field": "Microsoft.Compute/imageId",
-                "in": "[parameters('listOfWindowsImageIdToInclude')]"
+                "count": {
+                  "value": "[parameters('listOfWindowsImageIdToInclude')]",
+                  "name": "pattern",
+                  "where": {
+                    "field": "Microsoft.Compute/imageId",
+                    "like": "[current('pattern')]"
+                  }
+                },
+                "greater": 0
               },
               {
                 "allOf": [


### PR DESCRIPTION
Enable the use of a wildcard in the array param listOfWindowsImageIdToInclude.

Without the change, if you use custom images, you need to add the image id of every custom image version. For each new image version, you need to update the policy assignment. This is an extra administration step and can easily be forgotten. 

With the change you can use wildcards in the parameter 'listOfWindowsImageIdToInclude' and define which version (or all) of you custom images you want to use: 
E.g.:
[
"/subscriptions/<subscriptionId>/resourceGroups/YourResourceGroup/providers/Microsoft.Compute/images/ContosoStdImage/*"
]
to include all Image Versions of the ContosoStdImage