### PR TITLE
Fixed Azure policies for diagnostic settings for Service Bus

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/ServiceBus_DeployDiagnosticLog_Deploy_EventHub.json
+++ b/built-in-policies/policyDefinitions/Monitoring/ServiceBus_DeployDiagnosticLog_Deploy_EventHub.json
@@ -5,7 +5,7 @@
     "mode": "Indexed",
     "description": "Deploys the diagnostic settings for Service Bus to stream to a regional Event Hub when any Service Bus which is missing this diagnostic settings is created or updated.",
     "metadata": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "category": "Monitoring"
     },
     "parameters": {
@@ -162,6 +162,18 @@
                       "logs": [
                         {
                           "category": "OperationalLogs",
+                          "enabled": "[parameters('logsEnabled')]"
+                        },
+                        {
+                          "category": "VNetAndIPFilteringLogs",
+                          "enabled": "[parameters('logsEnabled')]"
+                        },
+                        {
+                          "category": "RuntimeAuditLogs",
+                          "enabled": "[parameters('logsEnabled')]"
+                        },
+                        {
+                          "category": "ApplicationMetricsLogs",
                           "enabled": "[parameters('logsEnabled')]"
                         }
                       ]

--- a/built-in-policies/policyDefinitions/Monitoring/ServiceBus_DeployDiagnosticLog_Deploy_LogAnalytics.json
+++ b/built-in-policies/policyDefinitions/Monitoring/ServiceBus_DeployDiagnosticLog_Deploy_LogAnalytics.json
@@ -5,7 +5,7 @@
     "mode": "Indexed",
     "description": "Deploys the diagnostic settings for Service Bus to stream to a regional Log Analytics workspace when any Service Bus which is missing this diagnostic settings is created or updated.",
     "metadata": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "category": "Monitoring"
     },
     "parameters": {
@@ -142,6 +142,14 @@
                         },
                         {
                           "category": "VNetAndIPFilteringLogs",
+                          "enabled": "[parameters('logsEnabled')]"
+                        },
+                        {
+                          "category": "RuntimeAuditLogs",
+                          "enabled": "[parameters('logsEnabled')]"
+                        },
+                        {
+                          "category": "ApplicationMetricsLogs",
                           "enabled": "[parameters('logsEnabled')]"
                         }
                       ]


### PR DESCRIPTION
Deploy Diagnostic Settings for Service Bus policies were never going into compliance since Azure was checking for all logs being enabled, but the policy itself was missing 2/3 new sources: VNetAndIPFilteringLogs, RuntimeAuditLogs and ApplicationMetricsLogs. Those have been added to the policies and will now be compliant after a remediation task