### PR TITLE
blinQ: Fix issue with wrong compliance state for blob storage with no table services.

### DIFF
--- a/built-in-policies/policyDefinitions/Storage/TableServicesLogsToWorkspace_DINE.json
+++ b/built-in-policies/policyDefinitions/Storage/TableServicesLogsToWorkspace_DINE.json
@@ -67,9 +67,19 @@
     },
     "policyRule": {
       "if": {
-        "field": "type",
-        "equals": "Microsoft.Storage/storageAccounts/tableServices"
-      },
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Storage/storageAccounts/tableServices"
+          },
+          {
+            "count": {
+              "field": "Microsoft.Storage/storageAccounts/tableServices/tables",
+              "greaterThan": 0
+            }
+          }
+        ]
+      },      
       "then": {
         "effect": "[parameters('effect')]",
         "details": {

--- a/built-in-policies/policyDefinitions/Storage/TableServicesLogsToWorkspace_DINE.json
+++ b/built-in-policies/policyDefinitions/Storage/TableServicesLogsToWorkspace_DINE.json
@@ -73,10 +73,8 @@
             "equals": "Microsoft.Storage/storageAccounts/tableServices"
           },
           {
-            "count": {
-              "field": "Microsoft.Storage/storageAccounts/tableServices/tables",
-              "greaterThan": 0
-            }
+            "field": "Microsoft.Storage/storageAccounts/tableServices/tables/tableName",
+            "exists": true
           }
         ]
       },      


### PR DESCRIPTION
The policy identify wrong policy state for blob storages with no table services.

We suggest this update to the policyRule to require at least 1 instance of tables.

