### PR TITLE
Add support for Sweden Central region to Azure Arc-related policies

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_HybridVM_Audit.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_HybridVM_Audit.json
@@ -63,6 +63,7 @@
               "southcentralus",
               "southeastasia",
               "southindia",
+              "swedencentral",
               "switzerlandnorth",
               "uaenorth",
               "uksouth",

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_HybridVM_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Linux_HybridVM_Deploy.json
@@ -63,6 +63,7 @@
               "southcentralus",
               "southeastasia",
               "southindia",
+              "swedencentral",
               "switzerlandnorth",
               "uaenorth",
               "uksouth",

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_HybridVM_Audit.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_HybridVM_Audit.json
@@ -63,6 +63,7 @@
               "southcentralus",
               "southeastasia",
               "southindia",
+              "swedencentral",
               "switzerlandnorth",
               "uaenorth",
               "uksouth",

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_HybridVM_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_Agent_Windows_HybridVM_Deploy.json
@@ -63,6 +63,7 @@
               "southcentralus",
               "southeastasia",
               "southindia",
+              "swedencentral",
               "switzerlandnorth",
               "uaenorth",
               "uksouth",

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Arc_Linux_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Arc_Linux_Deploy.json
@@ -88,6 +88,7 @@
               "southcentralus",
               "southeastasia",
               "southindia",
+              "swedencentral",
               "switzerlandnorth",
               "switzerlandwest",
               "uaenorth",

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Arc_Windows_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Arc_Windows_Deploy.json
@@ -88,6 +88,7 @@
               "southcentralus",
               "southeastasia",
               "southindia",
+              "swedencentral",
               "switzerlandnorth",
               "switzerlandwest",
               "uaenorth",

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Linux_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Linux_Deploy.json
@@ -88,6 +88,7 @@
               "southcentralus",
               "southeastasia",
               "southindia",
+              "swedencentral",
               "switzerlandnorth",
               "switzerlandwest",
               "uaenorth",

--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Windows_Deploy.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Windows_Deploy.json
@@ -88,6 +88,7 @@
               "southcentralus",
               "southeastasia",
               "southindia",
+              "swedencentral",
               "switzerlandnorth",
               "switzerlandwest",
               "uaenorth",


### PR DESCRIPTION
Azure Arc-enabled servers now support Sweden Central region but if you attempt to enable any of the Azure Policy resources that are applicable to Azure Arc-enabled servers, those policies will not be able to locate resources deployed in Sweden Central region, because the respective location is missing from the filter list.

I have now added `swedencentral` as an available location to the list in respective Azure Policy objects. This change has been tested and confirmed to be working - once it's added to the list, Azure Arc-enabled servers that are deployed in Sweden Central region are being properly identified by the respective policies.