### PR TITLE
Update Batch_DeployDiagnosticLog_Deploy_EventHub.json

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/Batch_DeployDiagnosticLog_Deploy_EventHub.json
+++ b/built-in-policies/policyDefinitions/Monitoring/Batch_DeployDiagnosticLog_Deploy_EventHub.json
@@ -1,202 +1,225 @@
 {
-  "properties": {
-    "displayName": "Deploy Diagnostic Settings for Batch Account to Event Hub",
-    "policyType": "BuiltIn",
-    "mode": "Indexed",
-    "description": "Deploys the diagnostic settings for Batch Account to stream to a regional Event Hub when any Batch Account which is missing this diagnostic settings is created or updated.",
-    "metadata": {
+   "properties": {
+      "displayName": "Deploy Diagnostic Settings for Batch Account to Event Hub",
+      "policyType": "BuiltIn",
+      "mode": "Indexed",
+      "description": "Deploys the diagnostic settings for Batch Account to stream to a regional Event Hub when any Batch Account which is missing this diagnostic settings is created or updated.",
+      "metadata": {
+         "version": "2.0.0",
+         "category": "Monitoring"
+      },
       "version": "2.0.0",
-      "category": "Monitoring"
-    },
-    "version": "2.0.0",
-    "parameters": {
-      "effect": {
-        "type": "string",
-        "defaultValue": "DeployIfNotExists",
-        "allowedValues": [
-          "DeployIfNotExists",
-          "Disabled"
-        ],
-        "metadata": {
-          "displayName": "Effect",
-          "description": "Enable or disable the execution of the policy"
-        }
-      },
-      "profileName": {
-        "type": "string",
-        "defaultValue": "setbypolicy_eventHub",
-        "metadata": {
-          "displayName": "Profile name",
-          "description": "The diagnostic settings profile name"
-        }
-      },
-      "eventHubRuleId": {
-        "type": "string",
-        "metadata": {
-          "displayName": "Event Hub Authorization Rule Id",
-          "description": "The Event Hub authorization rule Id for Azure Diagnostics. The authorization rule needs to be at Event Hub namespace level. e.g. /subscriptions/{subscription Id}/resourceGroups/{resource group}/providers/Microsoft.EventHub/namespaces/{Event Hub namespace}/authorizationrules/{authorization rule}",
-          "strongType": "Microsoft.EventHub/Namespaces/AuthorizationRules",
-          "assignPermissions": true
-        }
-      },
-      "eventHubLocation": {
-        "type": "String",
-        "metadata": {
-          "displayName": "Event Hub Location",
-          "description": "The location the Event Hub resides in. Only Batch Accounts in this location will be linked to this Event Hub.",
-          "strongType": "location"
-        },
-        "defaultValue": ""
-      },
-      "metricsEnabled": {
-        "type": "string",
-        "defaultValue": "False",
-        "allowedValues": [
-          "True",
-          "False"
-        ],
-        "metadata": {
-          "displayName": "Enable metrics",
-          "description": "Whether to enable metrics stream to the Event Hub - True or False"
-        }
-      },
-      "logsEnabled": {
-        "type": "string",
-        "defaultValue": "True",
-        "allowedValues": [
-          "True",
-          "False"
-        ],
-        "metadata": {
-          "displayName": "Enable logs",
-          "description": "Whether to enable logs stream to the Event Hub  - True or False"
-        }
-      }
-    },
-    "policyRule": {
-      "if": {
-        "allOf": [
-          {
-            "field": "type",
-            "equals": "Microsoft.Batch/batchAccounts"
-          },
-          {
-            "anyOf": [
-              {
-                "value": "[parameters('eventHubLocation')]",
-                "equals": ""
-              },
-              {
-                "field": "location",
-                "equals": "[parameters('eventHubLocation')]"
-              }
-            ]
-          }
-        ]
-      },
-      "then": {
-        "effect": "[parameters('effect')]",
-        "details": {
-          "type": "Microsoft.Insights/diagnosticSettings",
-          "name": "[parameters('profileName')]",
-          "existenceCondition": {
-            "allOf": [
-              {
-                "field": "Microsoft.Insights/diagnosticSettings/logs.enabled",
-                "equals": "[parameters('logsEnabled')]"
-              },
-              {
-                "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
-                "equals": "[parameters('metricsEnabled')]"
-              }
-            ]
-          },
-          "roleDefinitionIds": [
-            "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
-          ],
-          "deployment": {
-            "properties": {
-              "mode": "incremental",
-              "template": {
-                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                "contentVersion": "1.0.0.0",
-                "parameters": {
-                  "resourceName": {
-                    "type": "string"
-                  },
-                  "location": {
-                    "type": "string"
-                  },
-                  "eventHubRuleId": {
-                    "type": "string"
-                  },
-                  "metricsEnabled": {
-                    "type": "string"
-                  },
-                  "logsEnabled": {
-                    "type": "string"
-                  },
-                  "profileName": {
-                    "type": "string"
-                  }
-                },
-                "variables": {},
-                "resources": [
-                  {
-                    "type": "Microsoft.Batch/batchAccounts/providers/diagnosticSettings",
-                    "apiVersion": "2017-05-01-preview",
-                    "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
-                    "location": "[parameters('location')]",
-                    "dependsOn": [],
-                    "properties": {
-                      "eventHubAuthorizationRuleId": "[parameters('eventHubRuleId')]",
-                      "metrics": [
-                        {
-                          "category": "AllMetrics",
-                          "enabled": "[parameters('metricsEnabled')]",
-                          "retentionPolicy": {
-                            "enabled": false,
-                            "days": 0
-                          }
-                        }
-                      ],
-                      "logs": [
-                        {
-                          "category": "ServiceLog",
-                          "enabled": "[parameters('logsEnabled')]"
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "outputs": {}
-              },
-              "parameters": {
-                "location": {
-                  "value": "[field('location')]"
-                },
-                "resourceName": {
-                  "value": "[field('name')]"
-                },
-                "eventHubRuleId": {
-                  "value": "[parameters('eventHubRuleId')]"
-                },
-                "metricsEnabled": {
-                  "value": "[parameters('metricsEnabled')]"
-                },
-                "logsEnabled": {
-                  "value": "[parameters('logsEnabled')]"
-                },
-                "profileName": {
-                  "value": "[parameters('profileName')]"
-                }
-              }
+      "parameters": {
+         "effect": {
+            "type": "string",
+            "defaultValue": "DeployIfNotExists",
+            "allowedValues": [
+               "DeployIfNotExists",
+               "Disabled"
+            ],
+            "metadata": {
+               "displayName": "Effect",
+               "description": "Enable or disable the execution of the policy"
             }
-          }
-        }
+         },
+         "profileName": {
+            "type": "string",
+            "defaultValue": "setbypolicy_eventHub",
+            "metadata": {
+               "displayName": "Profile name",
+               "description": "The diagnostic settings profile name"
+            }
+         },
+         "eventHubRuleId": {
+            "type": "string",
+            "metadata": {
+               "displayName": "Event Hub Authorization Rule Id",
+               "description": "The Event Hub authorization rule Id for Azure Diagnostics. The authorization rule needs to be at Event Hub namespace level. e.g. /subscriptions/{subscription Id}/resourceGroups/{resource group}/providers/Microsoft.EventHub/namespaces/{Event Hub namespace}/authorizationrules/{authorization rule}",
+               "strongType": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+               "assignPermissions": true
+            }
+         },
+         "eventHubLocation": {
+            "type": "String",
+            "metadata": {
+               "displayName": "Event Hub Location",
+               "description": "The location the Event Hub resides in. Only Batch Accounts in this location will be linked to this Event Hub.",
+               "strongType": "location"
+            },
+            "defaultValue": ""
+         },
+         "eventHubName": {
+            "type": "String",
+            "metadata": {
+               "displayName": "Event Hub Name",
+               "description": "Specify the name of the Event Hub",
+               "strongType": "Microsoft.EventHub/Namespaces/EventHubs"
+            }
+         },
+         "metricsEnabled": {
+            "type": "string",
+            "defaultValue": "False",
+            "allowedValues": [
+               "True",
+               "False"
+            ],
+            "metadata": {
+               "displayName": "Enable metrics",
+               "description": "Whether to enable metrics stream to the Event Hub - True or False"
+            }
+         },
+         "logsEnabled": {
+            "type": "string",
+            "defaultValue": "True",
+            "allowedValues": [
+               "True",
+               "False"
+            ],
+            "metadata": {
+               "displayName": "Enable logs",
+               "description": "Whether to enable logs stream to the Event Hub  - True or False"
+            }
+         }
+      },
+      "policyRule": {
+         "if": {
+            "allOf": [
+               {
+                  "field": "type",
+                  "equals": "Microsoft.Batch/batchAccounts"
+               },
+               {
+                  "anyOf": [
+                     {
+                        "value": "[parameters('eventHubLocation')]",
+                        "equals": ""
+                     },
+                     {
+                        "field": "location",
+                        "equals": "[parameters('eventHubLocation')]"
+                     }
+                  ]
+               }
+            ]
+         },
+         "then": {
+            "effect": "[parameters('effect')]",
+            "details": {
+               "type": "Microsoft.Insights/diagnosticSettings",
+               "name": "[parameters('profileName')]",
+               "existenceCondition": {
+                  "allOf": [
+                     {
+                        "field": "Microsoft.Insights/diagnosticSettings/logs.enabled",
+                        "equals": "[parameters('logsEnabled')]"
+                     },
+                     {
+                        "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
+                        "equals": "[parameters('metricsEnabled')]"
+                     },
+                     {
+                        "field": "Microsoft.Insights/diagnosticSettings/eventHubAuthorizationRuleId",
+                        "matchInsensitively": "[parameters('eventHubRuleId')]"
+                     },
+                     {
+                        "field": "Microsoft.Insights/diagnosticSettings/eventHubName",
+                        "matchInsensitively": "[parameters('eventHubName')]"
+                     }
+                  ]
+               },
+               "roleDefinitionIds": [
+                  "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+               ],
+               "deployment": {
+                  "properties": {
+                     "mode": "incremental",
+                     "template": {
+                        "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                        "contentVersion": "1.0.0.0",
+                        "parameters": {
+                           "resourceName": {
+                              "type": "string"
+                           },
+                           "location": {
+                              "type": "string"
+                           },
+                           "eventHubRuleId": {
+                              "type": "string"
+                           },
+                           "eventHubName": {
+                              "type": "string"
+                           },
+                           "metricsEnabled": {
+                              "type": "string"
+                           },
+                           "logsEnabled": {
+                              "type": "string"
+                           },
+                           "profileName": {
+                              "type": "string"
+                           }
+                        },
+                        "variables": {},
+                        "resources": [
+                           {
+                              "type": "Microsoft.Batch/batchAccounts/providers/diagnosticSettings",
+                              "apiVersion": "2021-05-01-preview",
+                              "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+                              "location": "[parameters('location')]",
+                              "dependsOn": [],
+                              "properties": {
+                                 "eventHubAuthorizationRuleId": "[parameters('eventHubRuleId')]",
+                                 "eventHubName": "[parameters('eventHubName')]",
+                                 "metrics": [
+                                    {
+                                       "category": "AllMetrics",
+                                       "enabled": "[parameters('metricsEnabled')]",
+                                       "retentionPolicy": {
+                                          "enabled": false,
+                                          "days": 0
+                                       }
+                                    }
+                                 ],
+                                 "logs": [
+                                    {
+                                       "category": "ServiceLog",
+                                       "enabled": "[parameters('logsEnabled')]"
+                                    }
+                                 ]
+                              }
+                           }
+                        ],
+                        "outputs": {}
+                     },
+                     "parameters": {
+                        "location": {
+                           "value": "[field('location')]"
+                        },
+                        "resourceName": {
+                           "value": "[field('name')]"
+                        },
+                        "eventHubRuleId": {
+                           "value": "[parameters('eventHubRuleId')]"
+                        },
+                        "eventHubName": {
+                           "value": "[parameters('eventHubName')]"
+                        },
+                        "metricsEnabled": {
+                           "value": "[parameters('metricsEnabled')]"
+                        },
+                        "logsEnabled": {
+                           "value": "[parameters('logsEnabled')]"
+                        },
+                        "profileName": {
+                           "value": "[parameters('profileName')]"
+                        }
+                     }
+                  }
+               }
+            }
+         }
       }
-    }
-  },
-  "id": "/providers/Microsoft.Authorization/policyDefinitions/db51110f-0865-4a6e-b274-e2e07a5b2cd7",
-  "name": "db51110f-0865-4a6e-b274-e2e07a5b2cd7"
+   },
+   "id": "/providers/Microsoft.Authorization/policyDefinitions/db51110f-0865-4a6e-b274-e2e07a5b2cd7",
+   "name": "db51110f-0865-4a6e-b274-e2e07a5b2cd7"
 }


### PR DESCRIPTION
Parameterized the eventHubName so that it is possible to send data to a custom event hub instead of just an autogenerated one that will be created automatically if this field is empty in the diagnostic settings + updated API version to latest.