### PR TITLE
Disallow public bloc access policy name confusion

### DIFF
--- a/built-in-policies/policyDefinitions/Storage/ASC_Storage_DisallowPublicBlobAccess_Audit.json
+++ b/built-in-policies/policyDefinitions/Storage/ASC_Storage_DisallowPublicBlobAccess_Audit.json
@@ -5,7 +5,7 @@
     "mode": "Indexed",
     "description": "Anonymous public read access to containers and blobs in Azure Storage is a convenient way to share data but might present security risks. To prevent data breaches caused by undesired anonymous access, Microsoft recommends preventing public access to a storage account unless your scenario requires it.",
     "metadata": {
-      "version": "3.1.0-preview",
+      "version": "3.1.1-preview",
       "category": "Storage",
       "preview": true
     },

--- a/built-in-policies/policyDefinitions/Storage/ASC_Storage_DisallowPublicBlobAccess_Audit.json
+++ b/built-in-policies/policyDefinitions/Storage/ASC_Storage_DisallowPublicBlobAccess_Audit.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "displayName": "[Preview]: Storage account public access should be disallowed",
+    "displayName": "[Preview]: Storage account anonymous public access should be disallowed",
     "policyType": "BuiltIn",
     "mode": "Indexed",
     "description": "Anonymous public read access to containers and blobs in Azure Storage is a convenient way to share data but might present security risks. To prevent data breaches caused by undesired anonymous access, Microsoft recommends preventing public access to a storage account unless your scenario requires it.",

--- a/built-in-policies/policyDefinitions/Storage/ASC_Storage_DisallowPublicBlobAccess_Audit.json
+++ b/built-in-policies/policyDefinitions/Storage/ASC_Storage_DisallowPublicBlobAccess_Audit.json
@@ -9,7 +9,7 @@
       "category": "Storage",
       "preview": true
     },
-    "version": "3.1.0-preview",
+    "version": "3.1.1-preview",
     "parameters": {
       "effect": {
         "type": "string",


### PR DESCRIPTION
The policy has "displayName": "[Preview]: Storage account public access should be disallowed", which induce a lot of confusion to users since this does not disallow public access, but disallow anonymous (unauthenticated) public access to the storage account.
Suggestion: "displayName": "[Preview]: Storage account anonymous public access should be disallowed",

