### PR TITLE
Update LinkedService_ResourceType_Audit.json

### DIFF
--- a/built-in-policies/policyDefinitions/Data Factory/LinkedService_ResourceType_Audit.json
+++ b/built-in-policies/policyDefinitions/Data Factory/LinkedService_ResourceType_Audit.json
@@ -50,6 +50,7 @@
           "AzureSqlDatabase",
           "AzureSqlDW",
           "AzureSqlMI",
+          "AzureSynapseArtifacts",
           "AzureTableStorage",
           "Cassandra",
           "CommonDataServiceForApps",


### PR DESCRIPTION
Added "AzureSynapseArtifacts" to allowedValues

When deploying Linked Service of type - AzureSynapseArtifacts:
Resource 'LS_SynapseAnalytics_Artifacts' was disallowed by policy. Error Type: PolicyViolation, Policy Definition Name : Azure Data Factory linked service resource type should be in allow list, Policy Assignment Name : 704b5aca7bf7454a8f245fec.