### PR TITLE
Update AKS_GuardrailsMustHaveAntiAffinityRulesSet.json

### DIFF
--- a/built-in-policies/policyDefinitions/Kubernetes/AKS_GuardrailsMustHaveAntiAffinityRulesSet.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/AKS_GuardrailsMustHaveAntiAffinityRulesSet.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "displayName": "[Preview]: [AKS Guardrails] Must Have Anty Affinity Rules Set",
+    "displayName": "[Preview]: [AKS Guardrails] Must Have Anti-Affinity Rules Set",
     "policyType": "BuiltIn",
     "mode": "Microsoft.Kubernetes.Data",
     "description": "Requires affinity rules to be set.",


### PR DESCRIPTION
"Anty Affinity" should be "Anti-Affinity" (see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity for examples)