### PR TITLE
Adding MicrosoftSQLServer-WS2022 Image offer missing from detection to Azure Backup and Security Center related policies

### DIFF
--- a/built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithOutTag.json
+++ b/built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithOutTag.json
@@ -164,6 +164,10 @@
                     "anyOf": [
                       {
                         "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
                         "like": "*-WS2019"
                       },
                       {

--- a/built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithTag.json
+++ b/built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithTag.json
@@ -174,6 +174,10 @@
                     "anyOf": [
                       {
                         "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
                         "like": "*-WS2019"
                       },
                       {

--- a/built-in-policies/policyDefinitions/Backup/VirtualMachineBackup_Backup_DeployIfNotExists.json
+++ b/built-in-policies/policyDefinitions/Backup/VirtualMachineBackup_Backup_DeployIfNotExists.json
@@ -196,6 +196,10 @@
                     "anyOf": [
                       {
                         "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
                         "like": "*-WS2019"
                       },
                       {

--- a/built-in-policies/policyDefinitions/Backup/VirtualMachineWithTag_Backup_Deploy.json
+++ b/built-in-policies/policyDefinitions/Backup/VirtualMachineWithTag_Backup_Deploy.json
@@ -181,6 +181,10 @@
                     "anyOf": [
                       {
                         "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
                         "like": "*-WS2019"
                       },
                       {

--- a/built-in-policies/policyDefinitions/Security Center/ASC_AzureSecurityWindowsAgent_AuditIfNotExists.json
+++ b/built-in-policies/policyDefinitions/Security Center/ASC_AzureSecurityWindowsAgent_AuditIfNotExists.json
@@ -111,6 +111,10 @@
                     "anyOf": [
                       {
                         "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
                         "like": "*-WS2019"
                       },
                       {

--- a/built-in-policies/policyDefinitions/Security Center/ASC_AzureSecurityWindowsAgent_Deploy.json
+++ b/built-in-policies/policyDefinitions/Security Center/ASC_AzureSecurityWindowsAgent_Deploy.json
@@ -111,6 +111,10 @@
                     "anyOf": [
                       {
                         "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
                         "like": "*-WS2019"
                       },
                       {

--- a/built-in-policies/policyDefinitions/Security Center/ASC_AzureSecurityWindowsAgent_VMSS_AuditIfNotExists.json
+++ b/built-in-policies/policyDefinitions/Security Center/ASC_AzureSecurityWindowsAgent_VMSS_AuditIfNotExists.json
@@ -111,6 +111,10 @@
                     "anyOf": [
                       {
                         "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
                         "like": "*-WS2019"
                       },
                       {

--- a/built-in-policies/policyDefinitions/Security Center/ASC_AzureSecurityWindowsAgent_VMSS_Deploy.json
+++ b/built-in-policies/policyDefinitions/Security Center/ASC_AzureSecurityWindowsAgent_VMSS_Deploy.json
@@ -111,6 +111,10 @@
                     "anyOf": [
                       {
                         "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
                         "like": "*-WS2019"
                       },
                       {


### PR DESCRIPTION
There are several policies missing detection on the new MicrosoftSQLServer-WS2022 Image offer so I thought of creating just a PR to add where it's missing.

I know this is not the correct way of contributing to this Repository, but It's good for highlighting where it's missing.

I've opened issues for two of the policy definitions: #1197 ,  #1198  and I will probably open more for the other policies if necessary

hopefully, you can manage to include this in your next merge cycle of the Azure Policy.

Thanks in advance,
Haflidi Fridthjofsson
Microsoft Security MVP 
