### PR TITLE
Fix a typo, change specifc to specific

### DIFF
--- a/built-in-policies/policyDefinitions/Tags/DenyTag.json
+++ b/built-in-policies/policyDefinitions/Tags/DenyTag.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "displayName": "Requires resources to not have a specifc tag.",
+    "displayName": "Requires resources to not have a specific tag.",
     "policyType": "BuiltIn",
     "mode": "Indexed",
     "description": "Denies the creation of a resource that contains the given tag.  Does not apply to resource groups.",

--- a/built-in-policies/policySetDefinitions/Tags/DenyTag.json
+++ b/built-in-policies/policySetDefinitions/Tags/DenyTag.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "displayName": "Ensures resources to not have a specifc tag.",
+    "displayName": "Ensures resources to not have a specific tag.",
     "policyType": "BuiltIn",
     "description": "Denies the creation of a resource that contains the given tag.  Does not apply to resource groups.",
     "metadata": {


### PR DESCRIPTION
There is a spelling error in the name of the DenyTag policy. This PR fixes that.