### PR TITLE
Changes to apply Threat Protection Policy to NoSQL API Only

### DIFF
--- a/built-in-policies/policyDefinitions/Cosmos DB/CosmosDbAdvancedThreatProtection_Deploy.json
+++ b/built-in-policies/policyDefinitions/Cosmos DB/CosmosDbAdvancedThreatProtection_Deploy.json
@@ -25,8 +25,22 @@
     },
     "policyRule": {
       "if": {
-        "field": "type",
-        "equals": "Microsoft.DocumentDB/databaseAccounts"
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.DocumentDB/databaseAccounts"
+          },
+          {
+            "field": "Microsoft.DocumentDB/databaseAccounts/capabilities[*].name",
+            "notin": [
+              "EnableMongo",
+              "EnableCassandra",
+              "EnableTable",
+              "EnableGremlin"
+            ]
+          }
+        ]
+
       },
       "then": {
         "effect": "[parameters('effect')]",


### PR DESCRIPTION
Excluded Gremlin, Table, Mongo, and Cassandra from Threat Protection Check as it is not applicable to these APIs