### PR TITLE
Update AKS_DisableRunCommand_Deploy.json

### DIFF
--- a/built-in-policies/policyDefinitions/Kubernetes/AKS_DisableRunCommand_Deploy.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/AKS_DisableRunCommand_Deploy.json
@@ -110,7 +110,7 @@
                             "tags": "[if(contains(parameters('aksClusterContent'), 'tags'), parameters('aksClusterContent').tags, json('null'))]",
                             "properties": {
                               "kubernetesVersion": "[parameters('aksClusterContent').properties.kubernetesVersion]",
-                              "dnsPrefix": "[parameters('aksClusterContent').properties.dnsPrefix]",
+                              "dnsPrefix": "[if(contains(parameters('aksClusterContent').properties, 'dnsPrefix'), parameters('aksClusterContent').properties.dnsPrefix, json('null'))]",
                               "agentPoolProfiles": "[if(contains(parameters('aksClusterContent').properties, 'agentPoolProfiles'), parameters('aksClusterContent').properties.agentPoolProfiles, json('null'))]",
                               "linuxProfile": "[if(contains(parameters('aksClusterContent').properties, 'linuxProfile'), parameters('aksClusterContent').properties.linuxProfile, json('null'))]",
                               "windowsProfile": "[if(contains(parameters('aksClusterContent').properties, 'windowsProfile'), parameters('aksClusterContent').properties.windowsProfile, json('null'))]",


### PR DESCRIPTION
If dnsprefix is not set on the cluster then the policy will fail. So this check should prevent that.
However it might be more suitable to upgrade the ARM api version to a more recent level and make the upgrade only change one value and not write every value.