### PR TITLE
Update AzureSecurityCenter.json - Missing effects from list of allowedValues in assignment parameters

### DIFF
--- a/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
@@ -4525,6 +4525,7 @@
         "defaultValue": "Audit",
         "allowedValues": [
           "Audit",
+          "Deny",
           "Disabled"
         ],
         "metadata": {

--- a/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
@@ -4662,6 +4662,7 @@
         "defaultValue": "Audit",
         "allowedValues": [
           "Audit",
+          "Deny",
           "Disabled"
         ],
         "metadata": {
@@ -4686,6 +4687,7 @@
         "defaultValue": "Audit",
         "allowedValues": [
           "Audit",
+          "Deny",
           "Disabled"
         ],
         "metadata": {

--- a/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
@@ -4649,6 +4649,7 @@
         "defaultValue": "Audit",
         "allowedValues": [
           "Audit",
+          "Deny",
           "Disabled"
         ],
         "metadata": {

--- a/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
@@ -4721,6 +4721,7 @@
         "defaultValue": "Audit",
         "allowedValues": [
           "Audit",
+          "Deny",
           "Disabled"
         ],
         "metadata": {


### PR DESCRIPTION
Corrected available effect types for "Container registries should not allow unrestricted network access" in parameters.  Deny is also an available effect.  Spotted this when trying to assign the built in initiative using "Deny" for this policy and being informed it isn't a valid parameter even though on the underlying policy definition it is. 

https://www.azadvertizer.net/azpolicyadvertizer/d0793b48-0edc-4296-a390-4c75d1bdfd71.html