### PR TITLE
Added details in Known Issues for skipped evaluations for managed RGs (Microsoft.Databricks/workspaces & Microsoft.Solutions/applications), updated some formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ All cases of known resource types with anomalous policy behavior are listed here
 
 In some cases, certain RPs may return incomplete or otherwise limited or missing information about resources of a given type. The Azure Policy engine is unable to determine the compliance of any resources of such a type. Below are listed the known resource types exhibiting this problem.
 
-- Microsoft<span></span>.Web/sites/config/* (except Microsoft<span></span>.Web/sites/config/web)
-- Microsoft<span></span>.Web/sites/slots/config/* (except Microsoft<span></span>.Web/sites/slots/config/web)
+- `Microsoft<span></span>.Web/sites/config/*` (except `Microsoft<span></span>.Web/sites/config/web`)
+- `Microsoft<span></span>.Web/sites/slots/config/*` (except `Microsoft<span></span>.Web/sites/slots/config/web`)
 
 Currently, there is no plan to change this behavior for the above Microsoft.Web resource types. If this scenario is important to you, please [open a support ticket](https://azure.microsoft.com/support/create-ticket/) with the Web team.
 
-- Microsoft.HDInsights/clusters/computeProfile.roles[*].scriptActions
-- Microsoft.Sql/servers/auditingSettings
+- `Microsoft.HDInsights/clusters/computeProfile.roles[*].scriptActions`
+- `Microsoft.Sql/servers/auditingSettings`
   - This type will work correctly as the related resource in `AuditIfNotExists` and `DeployIfNotExists` policies, as long as a `name` for the resource is provided, e.g:
   ```       "effect": "AuditIfNotExists",
             "details": {
@@ -105,59 +105,58 @@ Currently, there is no plan to change this behavior for the above Microsoft.Web 
               "name": "default"
             }
    ```
-- Microsoft.DataLakeStore/accounts
+- `Microsoft.DataLakeStore/accounts`
   - This type behaves similarly to Microsoft.Sql/servers/auditingSettings. Compliance of some fields cannot be determined except in `AuditIfNotExists` and `DeployIfNotExists` policies.
-- Microsoft.DataLakeStore/accounts/encryptionState 
+- `Microsoft.DataLakeStore/accounts/encryptionState`
   - This property of this type is populated differently when queried than when created or updated unless non-standard parameters are provided. This means deny policies will work, but compliance audits will generally not be correct.
-- Microsoft.Sql 'master' database 
+- `Microsoft.Sql` 'master' database 
    - This type behaves similarly to Microsoft.Sql/servers/auditingSettings. Compliance of some fields cannot be determined except in `AuditIfNotExists` and `DeployIfNotExists` policies.
-- Microsoft.Compute/virtualMachines/instanceView
+- `Microsoft.Compute/virtualMachines/instanceView`
   - Collection query of this type is missing many properties, which means compliance checks may not work.
-- Microsoft.Network/virtualNetworks/subnets
+- `Microsoft.Network/virtualNetworks/subnets`
   - The routeTable property of this type is populated differently when queried than when created or updated unless non-standard parameters are provided. This means deny policies will work, but compliance audits will generally not be correct.
-- Microsoft.Insights/workbooks
+- `Microsoft.Insights/workbooks`
   - The collection GET API call for this type doesn't return all workbooks, which could result in some or all workbook resources being incorrectly flagged as non-compliant.
-- Microsoft.Maintenance/configurationAssignments
+- `Microsoft.Maintenance/configurationAssignments`
   - This type does not support LIST API which does not allow for compliance results to be populated.
-- Microsoft.Maintenance/applyUpdates
+- `Microsoft.Maintenance/applyUpdates`
   - This type does not support LIST API which does not allow for compliance results to be populated.
-- Microsoft.Cdn/CdnWebApplicationFirewallPolicies
+- `Microsoft.Cdn/CdnWebApplicationFirewallPolicies`
   - This type does not support LIST API which does not allow for compliance results to be populated. This type also does not support GET API calls at a subscription level which can lead to incorrect compliance results over time.
-- Microsoft.EventGrid/eventSubscriptions
+- `Microsoft.EventGrid/eventSubscriptions`
   - This type does not support LIST API which does not allow for compliance results to be populated.
 
 ### Resource Type not correctly published by resource provider
 
 In some cases, a resource provider may implement a resource type, but not correctly publish it to the Azure Resource Manager. The result of this is that Azure Policy is unable to discover the type in order to determine compliance. In some cases, this still allows deny policies to work, but compliance results will usually be incorrect. These are the resource types known to have this behavior:
 
-- Microsoft.DBforPostgreSQL/serverGroupsv2
-- Microsoft.AppConfiguration/ConfigurationStores
+- `Microsoft.DBforPostgreSQL/serverGroupsv2`
+- `Microsoft.AppConfiguration/ConfigurationStores`
 
 In some cases the unpublished resource type is actually a subtype of a published type, which causes aliases to refer to a parent type instead of the unpublished type. Evaluation of such policies fails, causing the policy to never apply to any resource.
 
 These resource types previously exhibited this behavior but have been fixed:
 
-- Microsoft.EventHub/namespaces/networkrulesets
-- Microsoft.ServiceBus/namespaces/networkrulesets
-- Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies
-- Microsoft.ApiManagement/service/portalsettings/delegation
-- Microsoft.Storage/storageAccounts/blobServices
+- `Microsoft.EventHub/namespaces/networkrulesets`
+- `Microsoft.ServiceBus/namespaces/networkrulesets`
+- `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies`
+- `Microsoft.ApiManagement/service/portalsettings/delegation`
+- `Microsoft.Storage/storageAccounts/blobServices`
 
 ### Resource management that bypasses Azure Resource Manager
 
 Resource providers are free to implement their own resource management operations outside of Azure Resource Manager ("dataplane" operations). In almost every Azure resource type, the distinction between resource management and dataplane operations is clear and the resource provider only implements resource management one way. Occasionally, a resource provider may choose to implement a type that can be managed both ways. In this case, Azure Policy controls the standard Azure Resource Manager API normally, but operations on the direct resource provider API to create, modify and delete resources of that type bypass Azure Resource Manager so they are invisible to Azure Policy. Since policy enforcement is incomplete, we recommend that customers do not implement policies targeting such a resource type.
 This is the list of known such resource types:
 
-- Microsoft.Storage/storageAccounts/blobServices/containers
+- `Microsoft.Storage/storageAccounts/blobServices/containers`
 
 The storage team has implemented blob public access control on storage accounts to address this scenario. Per-account public access control of blobs can be controlled by Azure Policy using the new alias ```Microsoft.Storage/storageAccounts/allowBlobPublicAccess```.
 
-
- - Microsoft.Sql/servers/firewallRules
+ - `Microsoft.Sql/servers/firewallRules`
 
 Firewall rules can be created/deleted/modified via T-SQL commands, which bypasses Azure Policy. There is currently no plan to address this.
 
-- Microsoft.ServiceFabric/clusters/applications
+- `Microsoft.ServiceFabric/clusters/applications`
 
 Service Fabric applications created via direct requests to the Service Fabric cluster (i.e. via New-ServiceFabricApplication) will not appear in the Azure Resource Manager representation of the Service Fabric cluster. Policy will not be able to audit/enforce these applications.
 
@@ -167,39 +166,39 @@ Note that Azure policies for dataplane operations of certain targeted resource p
 
 In a few instances, the creation pattern of a resource type doesn't follow normal REST patterns. In these cases, deny policies may not work or may only work for some properties. For example, certain resource types may PUT only a subset of the properties of the resource type to create the entire resource. With such types the resource provider selects the values for properties not provided in the payload. Such a resource might be created with a non-compliant value even though a deny policy exists to prevent it. A similar result may occur if a set of resource types can be created using a collection PUT. Known resource types that exhibit this class of behavior:
 
-- Microsoft.Automation/certificates
-- Microsoft.Security/securityContacts
+- `Microsoft.Automation/certificates`
+- `Microsoft.Security/securityContacts`
 
 There is currently no plan to change this behavior for these types. If this scenario is important to you, please [open a support ticket](https://azure.microsoft.com/support/create-ticket/) with the Azure SQL or Automation team.
 
 ### Nonstandard update pattern through Azure Portal
 In some cases, a resource provider can choose not to follow normal REST patterns when a resource is updated via the portal. In these cases, a partial PUT request is done instead of a PATCH request causing the policy engine to evaluate as if some properties do not have values. 
 
-- Microsoft.Web/sites 
+- `Microsoft.Web/sites`
 
 ### Provider pass-through to non Azure Resource Manager resources
 
 There are examples where a resource provider publishes a resource type to Azure Resource Manager, but the resources it represents cannot be managed by Azure Resource Manager. For example, Microsoft.Web has published several resource types to Azure Resource Manager that actually represent resources of the customer's site rather than Azure Resource Manager resources. Such resources cannot or should not be managed by Azure policy, and are explicitly excluded. All known examples are listed here:
 
-- Microsoft.Web/sites/deployments
-- Microsoft.Web/sites/functions
-- Microsoft.Web/sites/instances/deployments
-- Microsoft.Web/sites/siteextensions
-- Microsoft.Web/sites/slots/deployments
-- Microsoft.Web/sites/slots/functions
-- Microsoft.Web/sites/slots/instances/deployments
-- Microsoft.Web/sites/slots/siteextensions
-- Microsoft.Web/sites/sourcecontrols
-- Microsoft.Web/sites/slots/sourcecontrols
-- Microsoft.Web/sites/privateaccess
+- `Microsoft.Web/sites/deployments`
+- `Microsoft.Web/sites/functions`
+- `Microsoft.Web/sites/instances/deployments`
+- `Microsoft.Web/sites/siteextensions`
+- `Microsoft.Web/sites/slots/deployments`
+- `Microsoft.Web/sites/slots/functions`
+- `Microsoft.Web/sites/slots/instances/deployments`
+- `Microsoft.Web/sites/slots/siteextensions`
+- `Microsoft.Web/sites/sourcecontrols`
+- `Microsoft.Web/sites/slots/sourcecontrols`
+- `Microsoft.Web/sites/privateaccess`
 
 ### Legacy or incorrect aliases
 
-Since custom policies use aliases directly, it is usually not possible to update them without causing unintended side effects to existing custom policies. This means that aliases referring to incorrect information or following legacy naming conventions must be left in place, even though it may cause confusion. In certain cases where an alias is known to refer to the wrong information, another alias may be created as a corrected alternative to the known bad one. In these cases, the new alias will be given the name of the bad alias with .v2 appended. For example a bad alias named Microsoft.ResourceProvider/someType/someAlias would result in the addition of a corrected version named Microsoft.ResourceProvider/someType/someAlias.v2. If an alias is added to correct a .v2 alias it will be named by replacing v2 with v3. All known corrected aliases are listed here:
+Since custom policies use aliases directly, it is usually not possible to update them without causing unintended side effects to existing custom policies. This means that aliases referring to incorrect information or following legacy naming conventions must be left in place, even though it may cause confusion. In certain cases where an alias is known to refer to the wrong information, another alias may be created as a corrected alternative to the known bad one. In these cases, the new alias will be given the name of the bad alias with .v2 appended. For example a bad alias named `Microsoft.ResourceProvider/someType/someAlias` would result in the addition of a corrected version named `Microsoft.ResourceProvider/someType/someAlias.v2`. If an alias is added to correct a .v2 alias it will be named by replacing v2 with v3. All known corrected aliases are listed here:
 
-- Microsoft.Sql/servers/databases/requestedServiceObjectiveName.v2
+- `Microsoft.Sql/servers/databases/requestedServiceObjectiveName.v2`
 
-To enforce around SQL databases transparentDataEncryption, please use both the legacy alias (api versions between 2014-04-01 and 2022-05-01-preview) Microsoft.Sql/transparentDataEncryption.status and the new alias (post api version 2022-05-01-preview) Microsoft.Sql/servers/databases/transparentDataEncryption/state.  
+To enforce around SQL databases transparentDataEncryption, please use both the legacy alias (api versions between 2014-04-01 and 2022-05-01-preview) `Microsoft.Sql/transparentDataEncryption.status` and the new alias (post api version 2022-05-01-preview) `Microsoft.Sql/servers/databases/transparentDataEncryption/state`.  
 
 Resource property names that include symbols or numbers such as dashings '-' or slashes '/' are a nonstandard creation pattern and alias for those properities are not generated. 
 
@@ -207,33 +206,37 @@ Resource property names that include symbols or numbers such as dashings '-' or 
 
 In a few instances, when creating a resource from Azure Portal, the property is not set in the PUT request payload. When the request reaches the resource provider, the resource provider generates the property and sets the value. Because the property is not in the request payload, the policy cannot evaluate the property. Known resource fields that exhibit this class of behavior:
 
-- Microsoft.Storage/storageAccounts/networkAcls.defaultAction
-- Microsoft.Authorization/roleAssignments/principalType
-- Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType
-- Microsoft.Compute/virtualMachines/storageProfile.osDisk.diskSizeGB
-- Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile.storageProfile.osDisk.diskSizeGB
-- Microsoft.Compute/virtualMachineScaleSets/virtualMachines/storageProfile.osDisk.diskSizeGB
-- Microsoft.Authorization/roleAssignmentScheduleInstances/* (all aliases)
-- Microsoft.Cache/Redis/privateEndpointConnections[\*]
-- Microsoft.Cache/Redis/privateEndpointConnections[\*].provisioningState
-- Microsoft.Cache/Redis/privateEndpointConnections[\*].privateLinkServiceConnectionState.status
+- `Microsoft.Storage/storageAccounts/networkAcls.defaultAction`
+- `Microsoft.Authorization/roleAssignments/principalType`
+- `Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType`
+- `Microsoft.Compute/virtualMachines/storageProfile.osDisk.diskSizeGB`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile.storageProfile.osDisk.diskSizeGB`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/storageProfile.osDisk.diskSizeGB`
+- `Microsoft.Authorization/roleAssignmentScheduleInstances/* (all aliases)`
+- `Microsoft.Cache/Redis/privateEndpointConnections[\*]`
+- `Microsoft.Cache/Redis/privateEndpointConnections[\*].provisioningState`
+- `Microsoft.Cache/Redis/privateEndpointConnections[\*].privateLinkServiceConnectionState.status`
 
 Using this type of alias in the existence condition of auditIfNotExists or deployIfNotExists policies works correctly. These two kinds of effects will get the full resource content to evaluate the existence condition. The property is always present in GET request payloads.
 
 Using this type of alias in audit/deny/append effect policies works partially. The compliance scan result will be correct for existing resources. However, when creating/updating the resource, there will be no audit events for audit effect policies and no deny or append behaviors for deny/append effect policies because of the missing property in the request payload.
 
-- Microsoft.Databricks/* (Creation time only)
-
-All Databricks resources bypass policy enforcement at creation time. Databricks resources will have policy enforcement post-creation. To provide feedback on this, please leverage the [Databricks UserVoice](https://feedback.azure.com/forums/909463-azure-databricks). 
-
 ### Resources that are exempt from policy evaluation
 
-- Microsoft.Resources/*, except resource groups and subscriptions. 
+The following resource types bypass policy evaluation:
+- `Microsoft.Resources/*`, except resource groups and subscriptions. 
    - For example, `Microsoft.Resources/deployments` and `Microsoft.Resources/templateSpecs` are not evaluated by policy.
-- Microsoft.Billing/*
-- Microsoft.Capacity/reservationOrders/*
-- Microsoft.Help/*
-- Microsoft.Diagnostics/*
+- `Microsoft.Billing/*`
+- `Microsoft.Capacity/reservationOrders/*`
+- `Microsoft.Help/*`
+- `Microsoft.Diagnostics/*`
+
+There are also scenarios in which policy evaluation is skipped for resources in managed resource groups:
+- Cross-tenant requests in RGs managed by `Microsoft.Databricks/workspaces`
+  - Policy evaluation is skipped for these scenarios, which occur at creation time when the Databricks RP deploys locked resources needed to power the service within the managed RG. This is done so that customer policy assignments do not lead to partial deployment of these resources, which could cause inintended billing and inability to modify. 
+  - Databricks resources will have policy enforcement post-creation, when requests are made within the same tenant.
+  - To provide feedback on this deployment experience, please leverage the [Databricks UserVoice](https://feedback.azure.com/forums/909463-azure-databricks). 
+- Cross-tenant requests in RGs managed by `Microsoft.Solutions/applications`
 
 ### Resource types that exceed current enforcement and compliance scale
 
@@ -241,33 +244,33 @@ There some resource types that are generated at very high scale. These are not s
 
 These are resource types that have significant policy scenarios, but are not supported by Azure Policy due to the above scalability considerations:
 
-- Microsoft.ServiceBus/namespaces/topics
-- Microsoft.ServiceBus/namespaces/topics/authorizationRules
-- Microsoft.ServiceBus/namespaces/topics/subscriptions
-- Microsoft.ServiceBus/namespaces/topics/subscriptions/rules
+- `Microsoft.ServiceBus/namespaces/topics`
+- `Microsoft.ServiceBus/namespaces/topics/authorizationRules`
+- `Microsoft.ServiceBus/namespaces/topics/subscriptions`
+- `Microsoft.ServiceBus/namespaces/topics/subscriptions/rules`
 
 Work to increase the scale that policy can be performantly applied to resource types is in progress. Planned availability date is not yet determined.
 
 ### Alias changes  
 
-May 2020: Microsoft.DocumentDB/databaseAccounts/ipRangeFilter updated from a string property to an array.  Please re-author your custom definitions to support the property as an array.  
-July 2020: The alias Microsoft.Sql/servers/securityAlertPolicies/emailAddresses[] and related policies were deprecated. 
+May 2020: `Microsoft.DocumentDB/databaseAccounts/ipRangeFilter` updated from a string property to an array.  Please re-author your custom definitions to support the property as an array.  
+July 2020: The alias `Microsoft.Sql/servers/securityAlertPolicies/emailAddresses[]` and related policies were deprecated. 
 
 ### Resource types that do not display non-compliance messages in the portal during preflight validation   
 
 There are resource types that do not properly display non-compliance messages in the portal during preflight validation, but instead they show a link to the activity log.
 
 This behavior is seen in the following resource types:
-- Microsoft.Kusto/clusters
-- Microsoft.Cdn/profiles
-- Microsoft.ContainerRegistry/registries
-- Microsoft.Cache/Redis
+- `Microsoft.Kusto/clusters`
+- `Microsoft.Cdn/profiles`
+- `Microsoft.ContainerRegistry/registries`
+- `Microsoft.Cache/Redis`
 
 This behavior is also seen in resource types from the following RPs:
-- Microsoft.DataLakeAnalytics
-- Microsoft.DataLakeStore
-- Microsoft.DBforMySQL
-- Microsoft.HDInsight
+- `Microsoft.DataLakeAnalytics`
+- `Microsoft.DataLakeStore`
+- `Microsoft.DBforMySQL`
+- `Microsoft.HDInsight`
 
 ### Azure Policy Extension for Arc is not compatible on Kubernetes 1.25 (preview) version
 
@@ -284,25 +287,25 @@ For support involving these compliance message issues, please first follow up wi
 ### Resource types that do not support creation of Policy exemptions
 These resource types do not allow Policy exemptions on resources due to [deny assignments](https://docs.microsoft.com/azure/role-based-access-control/deny-assignments). Workaround is to use [exclusions](https://docs.microsoft.com/azure/governance/policy/concepts/assignment-structure#excluded-scopes) at the assignment level. 
 
-- Microsoft.Databricks/*
+- `Microsoft.Databricks/*`
 
 ### Resource types with unsupported property names
 Currently Azure Policy supports only alphanumeric characters for property and alias names. There are a handful of resource types with property names containing non-alphanumeric characters. These properties cannot currently be onboarded to Azure Policy:
 
-Microsoft.Cache/Redis/
-  - redisConfiguration.rdb-backup-enabled
-  - redisConfiguration.rdb-backup-frequency
-  - redisConfiguration.rdb-backup-max-snapshot-count
-  - redisConfiguration.rdb-storage-connection-string
-  - redisConfiguration.aof-storage-connection-string-0
-  - redisConfiguration.aof-storage-connection-string-1
-  - redisConfiguration.maxfragmentationmemory-reserved
-  - redisConfiguration.maxmemory-policy
-  - redisConfiguration.maxmemory-reserved
-  - redisConfiguration.maxmemory-delta
-  - redisConfiguration.aof-backup-enabled
-  - redisConfiguration.zonal-configuration
-  - redisConfiguration.preferred-data-archive-auth-method
-  - redisConfiguration.preferred-data-persistence-auth-method
+`Microsoft.Cache/Redis/`
+  - `redisConfiguration.rdb-backup-enabled`
+  - `redisConfiguration.rdb-backup-frequency`
+  - `redisConfiguration.rdb-backup-max-snapshot-count`
+  - `redisConfiguration.rdb-storage-connection-string`
+  - `redisConfiguration.aof-storage-connection-string-0`
+  - `redisConfiguration.aof-storage-connection-string-1`
+  - `redisConfiguration.maxfragmentationmemory-reserved`
+  - `redisConfiguration.maxmemory-policy`
+  - `redisConfiguration.maxmemory-reserved`
+  - `redisConfiguration.maxmemory-delta`
+  - `redisConfiguration.aof-backup-enabled`
+  - `redisConfiguration.zonal-configuration`
+  - `redisConfiguration.preferred-data-archive-auth-method`
+  - `redisConfiguration.preferred-data-persistence-auth-method`
 
 *This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.*


### PR DESCRIPTION
Summary of changes in this PR:
- Moved description from header **Optional or auto-generated resource property that bypasses policy evaluation** to header **Resources that are exempt from policy evaluation**.
- Added additional details around behavior of databricks managed RG resources skipping evaluation on cross tenant calls (creation time only, when the RP deploys the resources)
- Added callout for skipped evaluation in RGs managed by Microsoft.Solutions/applications too
- Added tik marks for the resource types in the new section I added. Then added tik marks for aliases & resource types throughout the README for consistency.

Main change:
![image](https://github.com/Azure/azure-policy/assets/93622349/eb74d5a0-95b2-42e9-b622-b448978a9995)
