### PR TITLE
Added ImageOffer office-365

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Windows_DINE.json
+++ b/built-in-policies/policyDefinitions/Monitoring/AzureMonitor_DCRA_Windows_DINE.json
@@ -353,9 +353,17 @@
                             "field": "Microsoft.Compute/imagePublisher",
                             "equals": "MicrosoftWindowsDesktop"
                           },
-                          {
-                            "field": "Microsoft.Compute/imageOffer",
-                            "like": "Windows-1*"
+                          { 
+                            "anyOf": [
+                              {
+                                "field": "Microsoft.Compute/imageOffer",
+                                "like": "Windows-1*"
+                              },
+                              {
+                                "field": "Microsoft.Compute/imageOffer",
+                                "like": "office-365"
+                              }
+                            ]
                           }
                         ]
                       }


### PR DESCRIPTION
Azure Virtual Desktops are often deployed with pre-installed M365 software package. This is Windows 10/11 but it's own image offer.