### PR TITLE
Fix typo in `Exclude Usage Costs Resources` desc

### DIFF
--- a/built-in-policies/policyDefinitions/General/ExcludeUsageCosts_Deny.json
+++ b/built-in-policies/policyDefinitions/General/ExcludeUsageCosts_Deny.json
@@ -3,7 +3,7 @@
     "displayName": "Exclude Usage Costs Resources",
     "policyType": "BuiltIn",
     "mode": "All",
-    "description": "This policy enables you to exlcude Usage Costs Resources. Usage costs include things like metered storage and Azure resources which are billed based on usage.",
+    "description": "This policy enables you to exclude Usage Costs Resources. Usage costs include things like metered storage and Azure resources which are billed based on usage.",
     "metadata": {
       "version": "1.0.0",
       "category": "General"


### PR DESCRIPTION
Fix typo in description of policy `Exclude Usage Costs Resources`