### PR TITLE
Allow to define the name of the diagnostic settings 

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/DataConnectorsAzureActivity.json
+++ b/built-in-policies/policyDefinitions/Monitoring/DataConnectorsAzureActivity.json
@@ -42,6 +42,14 @@
           "False"
         ],
         "defaultValue": "True"
+      },
+      "diagnosticSettingsName" : {
+        "type": "String",
+        "metadata": {
+          "displayName": "Diagnostic Settings Name",
+          "description": "Name of the diagnostic settings to be created"
+        },
+        "defaultValue": "subscriptionToLa"
       }
     },
     "policyRule": {
@@ -85,7 +93,7 @@
                 "variables": {},
                 "resources": [
                   {
-                    "name": "subscriptionToLa",
+                    "name": "[parameters('diagnosticSettingsName')]",
                     "type": "Microsoft.Insights/diagnosticSettings",
                     "apiVersion": "2017-05-01-preview",
                     "location": "Global",


### PR DESCRIPTION
Allow to define the name of the diagnostic settings that will be created but still providing the original name as default value.

The original policy definition has a static name being used for the diagnostic settings using "subscriptionToLa".