### PR TITLE
Fix AML CMK enabled policy to not flag project workspace kinds

### DIFF
--- a/built-in-policies/policyDefinitions/Azure Government/Machine Learning/Workspace_CMKEnabled_Audit.json
+++ b/built-in-policies/policyDefinitions/Azure Government/Machine Learning/Workspace_CMKEnabled_Audit.json
@@ -5,10 +5,10 @@
     "mode": "Indexed",
     "description": "Manage encryption at rest of Azure Machine Learning workspace data with customer-managed keys. By default, customer data is encrypted with service-managed keys, but customer-managed keys are commonly required to meet regulatory compliance standards. Customer-managed keys enable the data to be encrypted with an Azure Key Vault key created and owned by you. You have full control and responsibility for the key lifecycle, including rotation and management. Learn more at https://aka.ms/azureml-workspaces-cmk.",
     "metadata": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "category": "Machine Learning"
     },
-    "version": "1.0.3",
+    "version": "1.0.4",
     "parameters": {
       "effect": {
         "type": "String",
@@ -33,6 +33,12 @@
           },
           {
             "not": {
+              "field": "Microsoft.MachineLearningServices/workspaces/kind",
+              "equals": "project"
+            }
+          },
+          {
+            "not": {
               "field": "Microsoft.MachineLearningServices/workspaces/encryption.status",
               "equals": "enabled"
             }
@@ -44,7 +50,7 @@
       }
     },
     "versions": [
-      "1.0.3"
+      "1.0.4"
     ]
   },
   "id": "/providers/Microsoft.Authorization/policyDefinitions/ba769a63-b8cc-4b2d-abf6-ac33c7204be8",

--- a/built-in-policies/policyDefinitions/Machine Learning/Workspace_CMKEnabled_Audit.json
+++ b/built-in-policies/policyDefinitions/Machine Learning/Workspace_CMKEnabled_Audit.json
@@ -5,10 +5,10 @@
     "mode": "Indexed",
     "description": "Manage encryption at rest of Azure Machine Learning workspace data with customer-managed keys. By default, customer data is encrypted with service-managed keys, but customer-managed keys are commonly required to meet regulatory compliance standards. Customer-managed keys enable the data to be encrypted with an Azure Key Vault key created and owned by you. You have full control and responsibility for the key lifecycle, including rotation and management. Learn more at https://aka.ms/azureml-workspaces-cmk.",
     "metadata": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "category": "Machine Learning"
     },
-    "version": "1.0.3",
+    "version": "1.0.4",
     "parameters": {
       "effect": {
         "type": "String",
@@ -33,6 +33,12 @@
           },
           {
             "not": {
+              "field": "Microsoft.MachineLearningServices/workspaces/kind",
+              "equals": "project"
+            }
+          },
+          {
+            "not": {
               "field": "Microsoft.MachineLearningServices/workspaces/encryption.status",
               "equals": "enabled"
             }
@@ -44,7 +50,7 @@
       }
     },
     "versions": [
-      "1.0.3"
+      "1.0.4"
     ]
   },
   "id": "/providers/Microsoft.Authorization/policyDefinitions/ba769a63-b8cc-4b2d-abf6-ac33c7204be8",


### PR DESCRIPTION
As noted by this [issue](https://github.com/Azure/azure-policy/issues/1344), the AML CMK enabled policy should not flag project workspace kinds because they cannot set their own encryption property (it's inherited from the hub), only default and hub workspace kinds can set an encryption property.