### PR TITLE
fix: "Countainer Apps should disable external network access" triggers when no ingress

### DIFF
--- a/built-in-policies/policyDefinitions/Container Apps/ContainerAppInternal_Audit.json
+++ b/built-in-policies/policyDefinitions/Container Apps/ContainerAppInternal_Audit.json
@@ -32,16 +32,12 @@
             "equals": "Microsoft.App/containerApps"
           },
           {
-            "anyOf": [
-              {
-                "field": "Microsoft.App/containerApps/configuration.ingress",
-                "exists": false
-              },
-              {
-                "field": "Microsoft.App/containerApps/configuration.ingress.external",
-                "equals": true
-              }
-            ]
+            "field": "Microsoft.App/containerApps/configuration.ingress",
+            "exists": true
+          },
+          {
+            "field": "Microsoft.App/containerApps/configuration.ingress.external",
+            "equals": true
           }
         ]
       },


### PR DESCRIPTION
**Problem**

"Countainer Apps should disable external network access" policy erroneously triggers on container apps without ingress.

This causes the policy to incorrectly flag non-http workloads, and other workloads without ingress, as non-compliant.

**Solution**

Only validate `configuration.ingress.external` value if `configuration.ingress` exists.