### PR TITLE
Remove hardcoded location, fix minor typos

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/LogAnalyticsWorkspaces_DefaultWorkspace_DINE.json
+++ b/built-in-policies/policyDefinitions/Monitoring/LogAnalyticsWorkspaces_DefaultWorkspace_DINE.json
@@ -99,13 +99,13 @@
           "type": "Microsoft.OperationalInsights/workspaces",
           "name": "[parameters('workspaceName')]",
           "ResourceGroupName": "[parameters('rgName')]",
-          "existenceScope": "resourcegroup",
-          "deploymentScope": "Subscription",
+          "existenceScope": "resourceGroup",
+          "deploymentScope": "subscription",
           "roleDefinitionIds": [
             "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
           ],
           "deployment": {
-            "location": "West Central US",
+            "location": "[parameters('automationRegion')]",
             "properties": {
               "mode": "incremental",
               "parameters": {

--- a/built-in-policies/policyDefinitions/Monitoring/LogAnalyticsWorkspaces_DefaultWorkspace_DINE.json
+++ b/built-in-policies/policyDefinitions/Monitoring/LogAnalyticsWorkspaces_DefaultWorkspace_DINE.json
@@ -5,10 +5,10 @@
     "mode": "All",
     "description": "Deploy resource group containing Log Analytics workspace and linked automation account to centralize logs and monitoring. The automation account is aprerequisite for solutions like Updates and Change Tracking.",
     "metadata": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "category": "Monitoring"
     },
-    "version": "2.0.0",
+    "version": "3.0.0",
     "parameters": {
       "rgName": {
         "type": "String",
@@ -234,7 +234,7 @@
       }
     },
     "versions": [
-      "2.0.0"
+      "3.0.0"
     ]
   },
   "id": "/providers/Microsoft.Authorization/policyDefinitions/8e3e61b3-0b32-22d5-4edf-55f87fdb5955",


### PR DESCRIPTION
We tried deploying this in GCC High, but it failed since "West Central US" is hardcoded.  (This also answers my curiosity why our Azure Public Senitnel instance has a deployment in West Central US even though we don't have anything else in that region.)

I've tested this change in usgovvirginia and it works.  Let me know if this is the best way to fix this and I can create a PR for the rest of the hardcoded locations.

Fixes https://github.com/Azure/Enterprise-Scale/issues/1858, https://github.com/Azure/azure-policy/issues/960.