### PR TITLE
Update BlockAutomountToken.json

### DIFF
--- a/built-in-policies/policyDefinitions/Kubernetes/BlockAutomountToken.json
+++ b/built-in-policies/policyDefinitions/Kubernetes/BlockAutomountToken.json
@@ -67,7 +67,8 @@
           "kube-system",
           "gatekeeper-system",
           "azure-arc",
-          "azure-extensions-usage-system"
+          "azure-extensions-usage-system",
+          "dataprotection-microsoft"
         ]
       },
       "namespaces": {


### PR DESCRIPTION
Need to add "dataprotection-microsoft" namespace at the excludedNamespace. 
we can face the non-complaint state when we enable backup extension and azure policy in the AKS cluster. 
So it is better to add this namespace in the excludednamespace.