### PR TITLE
Update PrivateSubnetOnly_Audit.json

### DIFF
--- a/built-in-policies/policyDefinitions/Network/PrivateSubnetOnly_Audit.json
+++ b/built-in-policies/policyDefinitions/Network/PrivateSubnetOnly_Audit.json
@@ -5,10 +5,10 @@
     "mode": "All",
     "description": "Ensure your subnets are secure by default by preventing default outbound access. For more information go to https://aka.ms/defaultoutboundaccessretirement",
     "metadata": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "Network"
     },
-    "version": "1.0.0",
+    "version": "1.0.1",
     "parameters": {
       "effect": {
         "type": "String",
@@ -32,6 +32,12 @@
               {
                 "field": "type",
                 "equals": "Microsoft.Network/virtualNetworks"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.Network/virtualNetworks/subnets[*]"
+                },
+                "greater": 0
               },
               {
                 "field": "Microsoft.Network/virtualNetworks/subnets[*].defaultOutboundAccess",


### PR DESCRIPTION
Patched policy to version 1.0.1.

Updated to ensure count of subnets is > 0 prior to accessing values of defaultOutboundAccess in each subnet.  Required because otherwise if customer tries to PUT vnet without subnet array property, even if defaultoutboundaccess is set to false, the policy would originally block this.