### PR TITLE
Add destination type as parameter for diagnostic setting firewall policy

### DIFF
--- a/built-in-policies/policyDefinitions/Monitoring/DS_LA_network-azurefirewalls_DINE.json
+++ b/built-in-policies/policyDefinitions/Monitoring/DS_LA_network-azurefirewalls_DINE.json
@@ -61,6 +61,18 @@
           "strongType": "omsWorkspace",
           "assignPermissions": true
         }
+      },
+      "destinationType": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Destination Type",
+          "description": "Destination table type output in Log Analytics Workspace - null (AzureDiagnostics) or Dedicated (Resource Specific)"
+        },
+        "allowedValues": [
+          "null",
+          "Dedicated"
+        ],
+        "defaultValue": "null"
       }
     },
     "policyRule": {
@@ -136,6 +148,9 @@
                   },
                   "resourceName": {
                     "type": "string"
+                  },
+                  "destinationType": {
+                    "type": "String"
                   }
                 },
                 "variables": {},
@@ -145,6 +160,7 @@
                     "apiVersion": "2021-05-01-preview",
                     "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('diagnosticSettingName'))]",
                     "properties": {
+                      "logAnalyticsDestinationType": "[parameters('destinationType')]",
                       "workspaceId": "[parameters('logAnalytics')]",
                       "logs": [
                         {
@@ -175,6 +191,9 @@
                 },
                 "resourceName": {
                   "value": "[field('name')]"
+                },
+                "destinationType": {
+                  "value": "[parameters('destinationType')]"
                 }
               }
             }

--- a/built-in-policies/policySetDefinitions/Monitoring/AzureMonitor_DiagSettings_logAnalytics_allLogs.json
+++ b/built-in-policies/policySetDefinitions/Monitoring/AzureMonitor_DiagSettings_logAnalytics_allLogs.json
@@ -339,6 +339,18 @@
           "microsoft.web/hostingenvironments",
           "microsoft.workloads/sapvirtualinstances"
         ]
+      },
+      "destinationType": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Destination Type",
+          "description": "Destination table type output in Log Analytics Workspace - null (AzureDiagnostics) or Dedicated (Resource Specific)"
+        },
+        "allowedValues": [
+          "null",
+          "Dedicated"
+        ],
+        "defaultValue": "null"
       }
     },
     "policyDefinitions": [
@@ -2297,6 +2309,9 @@
           },
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
+          },
+          "destionationType": {
+            "value": "[parameters('destionationType')]"
           }
         }
       },


### PR DESCRIPTION
add destinationType as parameter and adjust properties in order to decide whether destination table in Log Analytics workspace should be AzureDiagnostic or Resource Specific.

This is only for the firewall policy definition and for the setDefinition. 

I assume this should be applied to all diagnostic setting definitions, in case this will be accepted. 