### PR TITLE
Api Managment Correct policyRule condition

### DIFF
--- a/built-in-policies/policyDefinitions/API Management/MinimumApiVersion_AuditDeny.json
+++ b/built-in-policies/policyDefinitions/API Management/MinimumApiVersion_AuditDeny.json
@@ -17,20 +17,24 @@
             "equals": "Microsoft.ApiManagement/service"
           },
           {
-            "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
-            "Match": "2019-12-01"
-          },
-          {
-            "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
-            "Match": "202#-##-##-preview"
-          },
-          {
-            "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
-            "Match": "202#-##-##"
-          },
-          {
             "field": "Microsoft.ApiManagement/service/sku.name",
             "notEquals": "Consumption"
+          },
+          {
+            "anyOf": [
+              {
+                "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
+                "Match": "2019-12-01"
+              },
+              {
+                "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
+                "Match": "202#-##-##-preview"
+              },
+              {
+                "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
+                "Match": "202#-##-##"
+              }
+            ]
           }
         ]
       },

--- a/built-in-policies/policyDefinitions/API Management/MinimumApiVersion_AuditDeny.json
+++ b/built-in-policies/policyDefinitions/API Management/MinimumApiVersion_AuditDeny.json
@@ -8,7 +8,7 @@
       "version": "1.0.2",
       "category": "API Management"
     },
-    "version": "1.0.1",
+    "version": "1.0.2",
     "policyRule": {
       "if": {
         "allOf": [

--- a/built-in-policies/policyDefinitions/API Management/MinimumApiVersion_AuditDeny.json
+++ b/built-in-policies/policyDefinitions/API Management/MinimumApiVersion_AuditDeny.json
@@ -5,7 +5,7 @@
     "mode": "Indexed",
     "description": "To prevent service secrets from being shared with read-only users, the minimum API version should be set to 2019-12-01 or higher.",
     "metadata": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "category": "API Management"
     },
     "version": "1.0.1",
@@ -18,15 +18,15 @@
           },
           {
             "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
-            "notMatch": "2019-12-01"
+            "Match": "2019-12-01"
           },
           {
             "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
-            "notMatch": "202#-##-##-preview"
+            "Match": "202#-##-##-preview"
           },
           {
             "field": "Microsoft.ApiManagement/service/apiVersionConstraint.minApiVersion",
-            "notMatch": "202#-##-##"
+            "Match": "202#-##-##"
           },
           {
             "field": "Microsoft.ApiManagement/service/sku.name",
@@ -54,7 +54,8 @@
       }
     },
     "versions": [
-      "1.0.1"
+      "1.0.1",
+      "1.0.2"
     ]
   },
   "id": "/providers/Microsoft.Authorization/policyDefinitions/549814b6-3212-4203-bdc8-1548d342fb67",


### PR DESCRIPTION
As mentioned in Issue #1011 the Policy is doing the exact opposite it should do.
It prevents using minimal API version 2019-12-01 or higher. 

With this change it will work as it should be.

The logic has been changed and should be compliant with the following rules
- The Type must be "Microsoft.ApiManagement/service"
- The Sku can not be "Consumption"
- The minApiVersion should be one of
  - 2019-12-01 (actually this version isn't available any more but it is in the name of the buildIn policy)
  - 202#-##-##.preview
  - 202#-##-##

