### PR TITLE
Fix Outputs Parameter Name

### DIFF
--- a/samples/Monitoring/apply-diagnostic-setting-keyvault-eventhub/azurepolicy.json
+++ b/samples/Monitoring/apply-diagnostic-setting-keyvault-eventhub/azurepolicy.json
@@ -159,7 +159,7 @@
                                 "outputs": {
                                     "policy": {
                                         "type": "string",
-                                        "value": "[concat(parameters('eventHubName'), 'configured for diagnostic logs for ', ': ', parameters('name'))]"
+                                        "value": "[concat(parameters('eventHubName'), 'configured for diagnostic logs for ', ': ', parameters('vaultName'))]"
                                     }
                                 }
                             },

--- a/samples/Monitoring/apply-diagnostic-setting-keyvault-eventhub/azurepolicy.rules.json
+++ b/samples/Monitoring/apply-diagnostic-setting-keyvault-eventhub/azurepolicy.rules.json
@@ -96,7 +96,7 @@
                         "outputs": {
                             "policy": {
                                 "type": "string",
-                                "value": "[concat(parameters('eventHubName'), 'configured for diagnostic logs for ', ': ', parameters('name'))]"
+                                "value": "[concat(parameters('eventHubName'), 'configured for diagnostic logs for ', ': ', parameters('vaultName'))]"
                             }
                         }
                     },

--- a/samples/Monitoring/apply-diagnostic-setting-keyvault-loganalytics/azurepolicy.json
+++ b/samples/Monitoring/apply-diagnostic-setting-keyvault-loganalytics/azurepolicy.json
@@ -149,7 +149,7 @@
                                 "outputs": {
                                     "policy": {
                                         "type": "string",
-                                        "value": "[concat(parameters('logAnalytics'), 'configured for diagnostic logs for ', ': ', parameters('name'))]"
+                                        "value": "[concat(parameters('logAnalytics'), 'configured for diagnostic logs for ', ': ', parameters('vaultName'))]"
                                     }
                                 }
                             },

--- a/samples/Monitoring/apply-diagnostic-setting-keyvault-loganalytics/azurepolicy.rules.json
+++ b/samples/Monitoring/apply-diagnostic-setting-keyvault-loganalytics/azurepolicy.rules.json
@@ -92,7 +92,7 @@
                         "outputs": {
                             "policy": {
                                 "type": "string",
-                                "value": "[concat(parameters('logAnalytics'), 'configured for diagnostic logs for ', ': ', parameters('name'))]"
+                                "value": "[concat(parameters('logAnalytics'), 'configured for diagnostic logs for ', ': ', parameters('vaultName'))]"
                             }
                         }
                     },


### PR DESCRIPTION
Fix error when generating Outputs.

> {"code":"DeploymentOutputEvaluationFailed","message":"Unable to evaluate template outputs: 'policy'. Please see error details and deployment operations. Please see https://aka.ms/arm-common-errors for usage details.","details":[{"code":"DeploymentOutputEvaluationFailed","target":"policy","message":"The template output 'policy' is not valid: The template parameter 'name' is not found. Please see https://aka.ms/arm-syntax-parameters for usage details.."}]}