### PR TITLE
Update Vaults_Immutability_Audit.json

### DIFF
--- a/built-in-policies/policyDefinitions/Backup/Vaults_Immutability_Audit.json
+++ b/built-in-policies/policyDefinitions/Backup/Vaults_Immutability_Audit.json
@@ -23,10 +23,10 @@
         ],
         "defaultValue": "Audit"
       },
-      "checkLockedImmutabiltyOnly": {
+      "checkLockedImmutabilityOnly": {
         "type": "Boolean",
         "metadata": {
-          "displayName": "CheckLockedImmutabiltyOnly",
+          "displayName": "CheckLockedImmutabilityOnly",
           "description": "This parameter checks if Immutability is locked for Backup Vaults in scope. Selecting 'true' will mark only vaults with Immutability 'Locked' as compliant. Selecting 'false' will mark vaults that have Immutability either 'Enabled' or 'Locked' as compliant."
         },
         "allowedValues": [
@@ -55,7 +55,7 @@
               {
                 "allOf": [
                   {
-                    "value": "[parameters('checkLockedImmutabiltyOnly')]",
+                    "value": "[parameters('checkLockedImmutabilityOnly')]",
                     "equals": true
                   },
                   {


### PR DESCRIPTION
The word "immutability" is wrongly spelled in the parameter, adding a chain of faulty logic as I would like to set the checkLockedImmutabilityOnly parameter from the assignment file (through the policySet file). Refer to the similar policy for Recovery Services vaults that has it correctly spelled.