### PR TITLE
Removed resource provider Microsoft.Media/mediaservices

### DIFF
--- a/built-in-policies/policySetDefinitions/SDN/AuditPublicNetworkAccessInitiative.json
+++ b/built-in-policies/policySetDefinitions/SDN/AuditPublicNetworkAccessInitiative.json
@@ -360,19 +360,6 @@
         ],
         "defaultValue": "Audit"
       },
-      "Effect-Microsoft.Media-mediaServices": {
-        "type": "String",
-        "metadata": {
-          "displayName": "Microsoft.Media/mediaservices Effect",
-          "description": "Set an effect for this resource type"
-        },
-        "allowedValues": [
-          "Audit",
-          "Deny",
-          "Disabled"
-        ],
-        "defaultValue": "Audit"
-      },
       "Effect-Microsoft.OperationalInsights-LogAnalytics": {
         "type": "String",
         "metadata": {
@@ -726,16 +713,6 @@
         "parameters": {
           "effect": {
             "value": "[parameters('Effect-Microsoft.MachineLearningServices-workspaces')]"
-          }
-        }
-      },
-      {
-        "policyDefinitionReferenceId": "AuditPublicNetworkAccessForMicrosoftMediaServices",
-        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/8bfe3603-0888-404a-87ff-5c1b6b4cc5e3",
-        "definitionVersion": "1.*.*",
-        "parameters": {
-          "effect": {
-            "value": "[parameters('Effect-Microsoft.Media-mediaServices')]"
           }
         }
       },


### PR DESCRIPTION
Removed Microsoft.Media/mediaservices because resource provider doesnt exist anymore. When create/updating or deleting the current version of this policy is errors on this resource provider.

- #1453 