### PR TITLE
update parameters effect for asc

### DIFF
--- a/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
+++ b/built-in-policies/policySetDefinitions/Security Center/AzureSecurityCenter.json
@@ -416,6 +416,18 @@
           "deprecated": true
         }
       },
+      "enableDefenderForApisEffect": {
+        "type": "string",
+        "defaultValue": "AuditIfNotExists",
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "metadata": {
+          "displayName": "Microsoft Defender for APIs should be enabled",
+          "description": "Enable or disable Microsoft Defender for APIs monitoring."
+        }
+      },
       "certificatesValidityPeriodMonitoringEffect": {
         "type": "string",
         "defaultValue": "disabled",
@@ -772,6 +784,18 @@
           "displayName": "Audit missing blob encryption for storage accounts",
           "description": "Enable or disable the monitoring of blob encryption for storage accounts",
           "deprecated": true
+        }
+      },
+      "defenderForStorageShouldBeEnabledMonitoringEffect": {
+        "type": "string",
+        "defaultValue": "AuditIfNotExists",
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "metadata": {
+          "displayName": "Microsoft Defender for Storage should be enabled",
+          "description": "Enable or disable the monitoring of Microsoft Defender for Storage"
         }
       },
       "jitNetworkAccessMonitoringEffect": {
@@ -6479,6 +6503,11 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7926a6d1-b268-4586-8197-e8ae90c877d7",
         "definitionVersion": "1.*.*",
         "policyDefinitionReferenceId": "enableDefenderForApis",
+        "parameters": {
+          "effect": {
+            "value": "[parameters('enableDefenderForApisEffect')]"
+          }
+        },
         "groupNames": [
           "Azure_Security_Benchmark_v3.0_DP-1",
           "Azure_Security_Benchmark_v3.0_DP-2",
@@ -8490,6 +8519,11 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/640d2586-54d2-465f-877f-9ffc1d2109f4",
         "definitionVersion": "1.*.*",
         "policyDefinitionReferenceId": "defenderForStorageShouldBeEnabledMonitoring",
+        "parameters": {
+          "effect": {
+            "value": "[parameters('defenderForStorageShouldBeEnabledMonitoringEffect')]"
+          }
+        },
         "groupNames": [
           "Azure_Security_Benchmark_v3.0_DP-2",
           "Azure_Security_Benchmark_v3.0_LT-1",


### PR DESCRIPTION
I was implementing the policies and noticed that defender for apis and the new defender for storage policy had not yet had their effects added to the parameter list