### PR TITLE
Error in default billing model defined within ASC_Azure_Defender_KeyVault_DINE.json

### DIFF
--- a/built-in-policies/policyDefinitions/Security Center/ASC_Azure_Defender_KeyVault_DINE.json
+++ b/built-in-policies/policyDefinitions/Security Center/ASC_Azure_Defender_KeyVault_DINE.json
@@ -29,10 +29,9 @@
           "description": "Select a Defender for Key Vault plan"
         },
         "allowedValues": [
-          "PerTransaction",
           "PerKeyVault"
         ],
-        "defaultValue": "PerTransaction"
+        "defaultValue": "PerKeyVault"
       }
     },
     "policyRule": {


### PR DESCRIPTION
PerTransaction is a legacy billing model for Microsoft Defender for Key Vaults. Refer to the pricing page: 

https://azure.microsoft.com/en-us/pricing/details/defender-for-cloud/?msockid=29406d91aabf61cc3b7b7b84ab94606e

You'll see it's only PerKeyVault now.