### PR TITLE
Skrall/add effect to guest config

### DIFF
--- a/built-in-policies/policyDefinitions/Guest Configuration/AddSystemIdentityWhenNone_Prerequisite.json
+++ b/built-in-policies/policyDefinitions/Guest Configuration/AddSystemIdentityWhenNone_Prerequisite.json
@@ -6,9 +6,23 @@
     "description": "This policy adds a system-assigned managed identity to virtual machines hosted in Azure that are supported by Guest Configuration but do not have any managed identities. A system-assigned managed identity is a prerequisite for all Guest Configuration assignments and must be added to machines before using any Guest Configuration policy definitions. For more information on Guest Configuration, visit https://aka.ms/gcpol.",
     "metadata": {
       "category": "Guest Configuration",
-      "version": "4.1.0"
+      "version": "4.2.0"
     },
-    "version": "4.1.0",
+    "version": "4.2.0",
+    "parameters": {
+      "effect": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of this policy"
+        },
+        "allowedValues": [
+          "Modify",
+          "Disabled"
+        ],
+        "defaultValue": "Modify"
+      }
+    },
     "policyRule": {
       "if": {
         "allOf": [
@@ -357,7 +371,7 @@
         ]
       },
       "then": {
-        "effect": "modify",
+        "effect": "[parameters('effect')]",
         "details": {
           "roleDefinitionIds": [
             "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
@@ -372,10 +386,7 @@
         }
       }
     },
-    "versions": [
-      "4.1.0",
-      "4.0.0"
-    ]
+    "versions": ["4.2.0", "4.1.0", "4.0.0"]
   },
   "id": "/providers/Microsoft.Authorization/policyDefinitions/3cf2ab00-13f1-4d0c-8971-2ac904541a7e",
   "name": "3cf2ab00-13f1-4d0c-8971-2ac904541a7e"

--- a/built-in-policies/policyDefinitions/Guest Configuration/DeployExtensionLinux_Prerequisite.json
+++ b/built-in-policies/policyDefinitions/Guest Configuration/DeployExtensionLinux_Prerequisite.json
@@ -6,9 +6,9 @@
     "description": "This policy deploys the Linux Guest Configuration extension to Linux virtual machines hosted in Azure that are supported by Guest Configuration. The Linux Guest Configuration extension is a prerequisite for all Linux Guest Configuration assignments and must be deployed to machines before using any Linux Guest Configuration policy definition. For more information on Guest Configuration, visit https://aka.ms/gcpol.",
     "metadata": {
       "category": "Guest Configuration",
-      "version": "3.2.0"
+      "version": "3.3.0"
     },
-    "version": "3.2.0",
+    "version": "3.3.0",
     "parameters": {
       "effect": {
         "type": "string",
@@ -271,6 +271,7 @@
       }
     },
     "versions": [
+      "3.3.0",
       "3.2.0",
       "3.1.0",
       "3.0.0"

--- a/built-in-policies/policyDefinitions/Guest Configuration/DeployExtensionLinux_Prerequisite.json
+++ b/built-in-policies/policyDefinitions/Guest Configuration/DeployExtensionLinux_Prerequisite.json
@@ -9,6 +9,21 @@
       "version": "3.2.0"
     },
     "version": "3.2.0",
+    "parameters": {
+      "effect": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of this policy"
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists"
+      }
+    },
     "policyRule": {
       "if": {
         "allOf": [
@@ -186,7 +201,7 @@
         ]
       },
       "then": {
-        "effect": "deployIfNotExists",
+        "effect": "[parameters('effect')]",
         "details": {
           "roleDefinitionIds": [
             "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"

--- a/built-in-policies/policyDefinitions/Guest Configuration/DeployExtensionWindows_Prerequisite.json
+++ b/built-in-policies/policyDefinitions/Guest Configuration/DeployExtensionWindows_Prerequisite.json
@@ -6,9 +6,9 @@
     "description": "This policy deploys the Windows Guest Configuration extension to Windows virtual machines hosted in Azure that are supported by Guest Configuration. The Windows Guest Configuration extension is a prerequisite for all Windows Guest Configuration assignments and must be deployed to machines before using any Windows Guest Configuration policy definition. For more information on Guest Configuration, visit https://aka.ms/gcpol.",
     "metadata": {
       "category": "Guest Configuration",
-      "version": "1.3.0"
+      "version": "1.4.0"
     },
-    "version": "1.3.0",
+    "version": "1.4.0",
     "parameters": {
       "effect": {
         "type": "string",
@@ -21,7 +21,7 @@
           "AuditIfNotExists",
           "Disabled"
         ],
-        "defaultValue": "AuditIfNotExists"
+        "defaultValue": "DeployIfNotExists"
       }
     },
     "policyRule": {
@@ -255,6 +255,7 @@
       }
     },
     "versions": [
+      "1.4.0",
       "1.3.0",
       "1.2.0"
     ]

--- a/built-in-policies/policyDefinitions/Guest Configuration/DeployExtensionWindows_Prerequisite.json
+++ b/built-in-policies/policyDefinitions/Guest Configuration/DeployExtensionWindows_Prerequisite.json
@@ -9,6 +9,21 @@
       "version": "1.3.0"
     },
     "version": "1.3.0",
+    "parameters": {
+      "effect": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of this policy"
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      }
+    },
     "policyRule": {
       "if": {
         "allOf": [
@@ -170,7 +185,7 @@
         ]
       },
       "then": {
-        "effect": "deployIfNotExists",
+        "effect": "[parameters('effect')]",
         "details": {
           "roleDefinitionIds": [
             "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"


### PR DESCRIPTION
Some very simple changes to expose the effect parameter for these policies to allow users to use these policies within policy sets, like what is done in the Enterprise Scale repo.

It may be good to note to maintainers, that generally, if the effect parameter isn't exposed, then it makes it really hard to use the policies within policy sets/initiatives. This should be a bare minimum parameter exposed on all policy definitions. The only exception I could imagine is if a policy definition is specifically only supposed to be used as a single definition and not within a policy set/initiative.