### PR TITLE
add contributor role to synapse policy

### DIFF
--- a/built-in-policies/policyDefinitions/Security Center/TdOnSynapseWorkspaces_DINE.json
+++ b/built-in-policies/policyDefinitions/Security Center/TdOnSynapseWorkspaces_DINE.json
@@ -39,7 +39,8 @@
             "equals": "Enabled"
           },
           "roleDefinitionIds": [
-            "/providers/microsoft.authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3"
+            "/providers/microsoft.authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3",
+            "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
           ],
           "deployment": {
             "properties": {


### PR DESCRIPTION
fixes #1091 

Ideal fix to follow principle of least privilege is to add permissions to the SQL Security Manager built-in role, but the issue has been ignored since 2023, so I went ahead and made it functional at least by adding the contributor role.