### PR TITLE
Adjust evaluation kinds for webapp policies

### DIFF
--- a/built-in-policies/policyDefinitions/App Service/WebApp_Audit_HTTP_Latest.json
+++ b/built-in-policies/policyDefinitions/App Service/WebApp_Audit_HTTP_Latest.json
@@ -32,7 +32,11 @@
           },
           {
             "field": "kind",
-            "notContains": "functionapp"
+            "like": "app*"
+          },
+          {
+            "field": "kind",
+            "notContains": ["functionapp", "workflowapp"]
           }
         ]
       },

--- a/built-in-policies/policyDefinitions/App Service/WebApp_PublicNetworkAccess_Audit.json
+++ b/built-in-policies/policyDefinitions/App Service/WebApp_PublicNetworkAccess_Audit.json
@@ -32,6 +32,14 @@
             "equals": "Microsoft.Web/sites"
           },
           {
+            "field": "kind",
+            "like": "app*"
+          },
+          {
+            "field": "kind",
+            "notContains": ["functionapp", "workflowapp"]
+          },
+          {
             "anyOf": [
               {
                 "field": "Microsoft.Web/sites/publicNetworkAccess",


### PR DESCRIPTION
WebApp policies should NOT evaluate Logic Apps and Function Apps unless explicitly desired.
Adjusted the policy rule to evaluate only the `app` kind from the overall namespace and report accurate compliance.