### PR TITLE
adding windows 2025 and ubuntu 24.04 images into Configure backup on …

### DIFF
--- a/built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithOutTag.json
+++ b/built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithOutTag.json
@@ -5,10 +5,10 @@
     "mode": "Indexed",
     "description": "Enforce backup for all virtual machines by deploying a recovery services vault in the same location and resource group as the virtual machine. Doing this is useful when different application teams in your organization are allocated separate resource groups and need to manage their own backups and restores. You can optionally exclude virtual machines containing a specified tag to control the scope of assignment. See https://aka.ms/AzureVMAppCentricBackupExcludeTag.",
     "metadata": {
-      "version": "9.4.0",
+      "version": "9.5.0",
       "category": "Backup"
     },
-    "version": "9.4.0",
+    "version": "9.5.0",
     "parameters": {
       "exclusionTagName": {
         "type": "String",
@@ -118,7 +118,20 @@
                       "2022-datacenter-core",
                       "2022-datacenter-core-smalldisk-g2",
                       "2022-datacenter-core-smalldisk",
-                      "2022-datacenter-azure-edition-hotpatch"
+                      "2022-datacenter-azure-edition-hotpatch",
+                      "2025-datacenter",
+                      "2025-datacenter-azure-edition",
+                      "2025-datacenter-azure-edition-smalldisk",
+                      "2025-datacenter-azure-edition-core",
+                      "2025-datacenter-azure-edition-core-smalldisk",
+                      "2025-datacenter-core",
+                      "2025-datacenter-core-g2",
+                      "2025-datacenter-core-smalldisk",
+                      "2025-datacenter-core-smalldisk-g2",
+                      "2025-datacenter-g2",
+                      "2025-datacenter-smalldisk",
+                      "2025-datacenter-smalldisk-g2",
+                      "server2025upgrade"
                     ]
                   }
                 ]
@@ -194,6 +207,22 @@
                       },
                       {
                         "anyOf": [
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "like": "*-WS2025"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "like": "*-WS2025-BYOL"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "like": "*-WS2022"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "like": "*-WS2022-BYOL"
+                          },
                           {
                             "field": "Microsoft.Compute/imageOffer",
                             "like": "*-WS2019"
@@ -415,6 +444,10 @@
                       {
                         "field": "Microsoft.Compute/imageSKU",
                         "like": "22_04-lts-gen2"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "like": "24_04-lts"
                       }
                     ]
                   }

--- a/built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithTag.json
+++ b/built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithTag.json
@@ -5,10 +5,10 @@
     "mode": "Indexed",
     "description": "Enforce backup for all virtual machines by deploying a recovery services vault in the same location and resource group as the virtual machine. Doing this is useful when different application teams in your organization are allocated separate resource groups and need to manage their own backups and restores. You can optionally include virtual machines containing a specified tag to control the scope of assignment. See https://aka.ms/AzureVMAppCentricBackupIncludeTag.",
     "metadata": {
-      "version": "9.4.0",
+      "version": "9.5.0",
       "category": "Backup"
     },
-    "version": "9.4.0",
+    "version": "9.5.0",
     "parameters": {
       "inclusionTagName": {
         "type": "String",
@@ -128,7 +128,20 @@
                       "2022-datacenter-core",
                       "2022-datacenter-core-smalldisk-g2",
                       "2022-datacenter-core-smalldisk",
-                      "2022-datacenter-azure-edition-hotpatch"
+                      "2022-datacenter-azure-edition-hotpatch",
+                      "2025-datacenter",
+                      "2025-datacenter-azure-edition",
+                      "2025-datacenter-azure-edition-smalldisk",
+                      "2025-datacenter-azure-edition-core",
+                      "2025-datacenter-azure-edition-core-smalldisk",
+                      "2025-datacenter-core",
+                      "2025-datacenter-core-g2",
+                      "2025-datacenter-core-smalldisk",
+                      "2025-datacenter-core-smalldisk-g2",
+                      "2025-datacenter-g2",
+                      "2025-datacenter-smalldisk",
+                      "2025-datacenter-smalldisk-g2",
+                      "server2025upgrade"
                     ]
                   }
                 ]
@@ -204,6 +217,22 @@
                       },
                       {
                         "anyOf": [
+                                                    {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "like": "*-WS2025"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "like": "*-WS2025-BYOL"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "like": "*-WS2022"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "like": "*-WS2022-BYOL"
+                          },
                           {
                             "field": "Microsoft.Compute/imageOffer",
                             "like": "*-WS2019"
@@ -425,6 +454,10 @@
                       {
                         "field": "Microsoft.Compute/imageSKU",
                         "like": "22_04-lts-gen2"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "like": "24_04-lts"
                       }
                     ]
                   }


### PR DESCRIPTION
This pull request updates the policy definition VirtualMachineApplicationCentricBackup_DINE_WithOutTag and built-in-policies/policyDefinitions/Backup/VirtualMachineApplicationCentricBackup_DINE_WithTag.json to expand support for new Windows Server 2025 and Ubuntu 24.04-LTS images, as well as to increment the policy version.

Key Changes

- Version Bump: Updated the policy version from 9.4.0 to 9.5.0 in both metadata and the root object.

- Windows Server 2025 Support: Added multiple new Windows Server 2025 SKUs (including core, Azure edition, smalldisk, and G2 variants) to the allowed image list. Updated image offer filters to match new 2025 Windows Server releases (*-WS2025 and *-WS2025-BYOL).

- Ubuntu 24.04-LTS Support: Added "24_04-lts" to the list of recognized Ubuntu image SKUs for backup enforcement.