### PR TITLE
APIM built-in policy: Update allowed values for SKUs in VNETEnabled_A…

### DIFF
--- a/built-in-policies/policyDefinitions/API Management/VNETEnabled_Audit.json
+++ b/built-in-policies/policyDefinitions/API Management/VNETEnabled_Audit.json
@@ -33,12 +33,16 @@
           "Developer",
           "Basic",
           "Standard",
+          "StandardV2",
           "Premium",
+          "PremiumV2",
           "Consumption"
         ],
         "defaultValue": [
           "Developer",
-          "Premium"
+          "StandardV2",
+          "Premium",
+          "PremiumV2"
         ]
       }
     },


### PR DESCRIPTION
This pull request updates the `VNETEnabled_Audit.json` policy definition for API Management SKUs to include support for new SKU variants. The main change is the addition of `StandardV2` and `PremiumV2` to both the allowed values and the default values, ensuring the policy can be applied to these newer SKUs.

**Policy SKU support updates:**

* Added `StandardV2` and `PremiumV2` to the list of allowed API Management SKUs in the `VNETEnabled_Audit.json` policy definition.
* Updated the default values for SKUs to include `StandardV2` and `PremiumV2`, alongside `Premium`.