### PR TITLE
Update StorageAccountCustomerManagedKeyEnabled_Audit.json

### DIFF
--- a/built-in-policies/policyDefinitions/Storage/StorageAccountCustomerManagedKeyEnabled_Audit.json
+++ b/built-in-policies/policyDefinitions/Storage/StorageAccountCustomerManagedKeyEnabled_Audit.json
@@ -18,6 +18,7 @@
         },
         "allowedValues": [
           "Audit",
+          "Deny",
           "Disabled"
         ],
         "defaultValue": "Audit"


### PR DESCRIPTION
I can not find a proper built-in policy allowing to enforce the usage of CMK on a storage account. This policy misses according to me the deny parameter.