### PR TITLE
Add azure-arg-external-evaluation-policy-author skill bundle

### DIFF
--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/README.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/README.md
@@ -1,0 +1,45 @@
+# Azure Policy External Evaluation (ARG) authoring assistant
+
+> Note: This skill is meant to be shared with Azure customers. Do not include links to internal docs and other data sources.
+
+This folder contains AI skill for authoring and testing **Azure Policy External Evaluation policies that query Azure Resource Graph (ARG)**. (This feature is sometimes referred to colloquially as "Invoke"; the rest of this bundle uses the formal name.)
+
+The goal of this skill is to help customers registered to the private preview to get familiar and experiment with the new concept of external evaluations.
+
+The skill takes a free-text intent for an enforcement policy that queries ARG, decides feasibility against the known limits and gotchas, iterates on the desired query (via `az graph query`), and helps create the policy definitions, a `.http` file with a test flow, and a detailed explanation of the policy's structure.
+
+> Note: This skill is authored to work within the limits of the external evaluations feature as of May 2026. Some of these limits might change in the future.
+
+## Usage
+
+This bundle is packaged as an [agent skill](https://code.visualstudio.com/docs/copilot/customization/agent-skills) (`SKILL.md` at the root with YAML frontmatter, supporting `knowledge/`, `templates/`, and `examples/` folders alongside).
+
+### GitHub Copilot
+
+Drop the entire folder into one of the skill locations Copilot discovers automatically.
+
+## Prerequisites
+
+- Your tenant is onboarded to the External Evaluation policies private preview.
+- `az` CLI logged in (`az login`) with at least Reader on the subscription you'll be testing against. Used by the agent to run `az graph query` during the KQL co-design loop.
+- A real subscription with resources relevant to the ARG query.
+
+## Folder layout
+
+```
+azure-policy-invoke-arg-author/
+├── README.md                                    # this file
+├── SKILL.md                                     # skill entry point (frontmatter + system prompt)
+├── knowledge/
+│   ├── 01-overview.md                           # what it is, when not to use it
+│   ├── 02-policy-artifacts-shape.md             # canonical JSON for definition + assignment, field by field
+│   └── 03-rest-flow.md                          # acquirePolicyToken contract, the 403 you'll see
+├── templates/
+│   └── test-flow.template.http
+└── examples/
+    ├── 01-deny-nsg-overshared/
+    ├── 02-deny-immutable-tag-on-nsg/
+    └── 03-denyaction-actiongroup-in-use/
+```
+
+Each example folder contains a `policy-definition.json`, a `test-flow.http`, and an `EXPLANATION.md` (what the policy does, the test queries run during co-design, how to verify via Portal / CLI / REST).

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/SKILL.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: azure-arg-external-evaluation-policy-author
+description: Use when the user wants to author, design, or test an Azure Policy that queries Azure Resource Graph (ARG) at request-time — i.e. a policy whose deny/audit decision depends on data from elsewhere in the subscription (sibling/parent resource state, RG-wide invariants, multi-hop relationships, etc.). Formally called Azure Policy External Evaluation; sometimes referred to colloquially as "Invoke". Drives an iterative KQL co-design loop against the user's real subscription via `az graph query`, then emits a policy definition, assignment, `.http` test flow, and an `EXPLANATION.md` companion. Read-only; never provisions anything.
+---
+
+# Azure Policy External Evaluation (ARG) authoring
+
+Procedure for authoring and testing an **enforcement Azure Policy that queries Azure Resource Graph (ARG)**, utilizing the new **External Evaluation** features. Follow the workflow below when the user asks for a policy whose decision depends on ARG data.
+
+The output of the procedure is a folder containing: a `policy-definition.json`, a `test-flow.http`, and an `EXPLANATION.md`. The policy assignment body lives inline in the `.http` file (see step 4 below). A secondary goal of this procedure is to help users learn about the new External Evaluation feature.
+
+The procedure never provisions anything in the user's subscription; the only Azure side-effects are read-only ARG queries via `az graph query`.
+
+Knowledge files referenced throughout — read them **as needed**:
+
+- [`knowledge/01-overview.md`](./knowledge/01-overview.md) — what External Evaluation + ARG is and known feature limits
+- [`knowledge/02-policy-artifacts-shape.md`](./knowledge/02-policy-artifacts-shape.md) — canonical JSON for definition + assignment, field by field, with locks and leeway
+- [`knowledge/03-rest-flow.md`](./knowledge/03-rest-flow.md) — Token API REST contracts, response shapes, the 403 to expect
+
+Also available: [`templates/`](./templates/) (canonical skeletons) and [`examples/`](./examples/) (worked end-to-end scenarios).
+
+---
+
+## Rules
+
+- **Never modify, create, or delete anything in the user's subscription.** ARG queries via `az graph query` are read-only and are the only Azure side-effects you produce.
+- **Stay within External Evaluation + ARG's limits.** If the user ask can't be achieved with the existing capabilities, say so plainly, explain why and stop.
+   - If the user asks for a policy that doesn't need an ARG call but they want to use it anyway, let them know and continue with creating the policy if they're ok with it.
+- **Your generated artifacts should strictly follow the pattern described in the knowledge base**.
+- **Work with the user to create and test the ARG query**. Always run the co-design process.
+- **Cite a knowledge file or official docs** every time you justify a non-obvious choice (e.g. "queryWithUserIdentity: true — see the shape doc"). No bare hand-waving. Goal is to ensure that you are accountable to the accuracy of your decisions as well as educating the user.
+
+---
+
+## Workflow
+
+### Step 0 - Read the overview doc
+
+[`knowledge/01-overview.md`](./knowledge/01-overview.md)
+External Evaluation is new and not yet covered by public documentation. Prior context and official docs will not fill in the gaps — read the overview first.
+
+### Step 1 — Intake & feasibility
+
+Goal is to reach a mutual agreement with the user about what the policy is doing and whether it's feasible to utilize the External Evaluation feature.
+
+1. **Restate the free-text policy intent in one sentence. Reiterate based on user feedback until they approve**:
+   - Name which resource operations are targeted: operation type (write/delete, could be implicit), resource type and any other constraints on the resource payload.
+   - Loosely describe what the ARG query returns and which returned values will result in denial.
+   - Example: "Deny the association of an NSG to a subnet if an ARG query that counts other subnets using the NSG returns a number greater than 3"
+2. **Feasibility check.** Walk through these reasons-to-reject:
+   - Is the invariant **within one subscription**? Cross-sub / cross-tenant / MG-scoped → reject.
+   - The ARG query must return a result that has a single column and 0 or 1 rows. Can the invariant collapse to **one boolean or scalar**?
+      - This means that parts of the policy logic will have to be shifted to the ARG query side. e.g. instead of an `allOf: [ claims().a == 1, claims().b == 2]` in the policy condition, the ARG query will have a `| project a == 1 and b == 2` statement.
+      - Common ways to return a single result is to have the query filter by a specific resource id, or use `summarize`
+      - Try hard - ARG language is more capable than the policy language and it's most likely doable. Only reject if you genuinely cannot.
+   - Is the desired effect in `{audit, deny, auditAction, denyAction}`?
+   When rejecting, state the reason plainly, point at the relevant knowledge file section, and suggest the closest standard-policy alternative if one exists. Then stop.
+
+### Step 2 — KQL co-design with the user
+
+Goal is to work with the user to compose and test a draft of the query that will be used in the policy.
+
+The main challenge with the new kind of policies is that any meaningful use case will require formatting the ARG query at evaluation time, plugging in details from the evaluated resource or policy parameter values. This means that the policy definition you'll author will likely have ugly `[format()]` expressions that construct the query, with the necessary runtime details plugged in via expressions like `[field()]` and `[parameters()]`, as well as escaping any quotes. This expression is not very human readable and extremely hard to manually convert to and from a runnable ARG query for testing. You are to shield the user from this complexity. Help them author and test a "regular" ARG query against a real environment, being mindful (and helping the user understand) about the parts of the query that will need to be parameterized at runtime vs parts of the query that are meant to perform the desired logic.
+
+1. Get the initial query that captures the intent.
+   - Ask the user if they have a working sample query that they want to use as a starting point. The query doesn't have to conform to the added rules and limitations of the policy. It should express the general idea.
+   - If they don't have a query, suggest a starting query for them and ask for feedback. Your query should focus on the core logic. Don't add any collapsing logic yet.
+   - For example, for the NSG oversharing example (see [`examples/01-deny-nsg-overshared/`](./examples/01-deny-nsg-overshared/)), the starting query can return all pairs of associated subnet-nsgs:
+      - `resources | where type =~ "microsoft.network/networksecuritygroups" | mv-expand subnet = properties["subnets"] | project nsgId = id, subnetId = subnet["id"]`
+2. Sanity check query run:
+   - Ask the user for permission to run the query, as well as against which subscriptions to run it — we want a test subscription where the query will return results.
+   - Run the query, analyze the results and present them to the user, raising any potential issues with the query or the quality of the test data set, as well as asking if it makes sense to them.
+   - Loop with the user until they have confidence that the query returns the right data to drive the requested policy.
+3. Re-write the query in a policy-friendly form:
+   - Add additional filters if the initial query is too broad — the policy query needs to only return results that are relevant to the evaluated resource.
+   - Try to separate between conditions that will require parameterization and any conditions that act only on the properties of the queried resources.
+   - Your filters should use hard coded values that you know will yield results from the test set.
+   - Apply the necessary consolidation.
+   - Going with the NSG oversharing example above, the revised query will be: `resources | where type =~ "microsoft.network/networksecuritygroups" | where id == '<hard coded NSG Id that will be populated in runtime in the policy>' | mv-expand subnet = properties["subnets"] | where isnotnull(subnet["id"]) | where subnet["id"] !~ '<hard coded subnet Id that will be populated in runtime in the policy>' | summarize otherSubnetsCount = count()`
+      - In this revised query, we imagine that the policy will target subnets, and that we'll have 2 dynamic values in the ARG query: which NSG we're about to add to the subnet (so that we can find who else uses it) as well as the id of the evaluated subnet, so that we can exclude it from the count if it's already attached to this NSG. We also consolidate the results by using a `summarize count()` aggregation.
+   - Share this query with the user, explain what you did and why, run it and ensure the results make sense. You may need to produce multiple versions of the query with different placeholder values hard-coded into it for different test cases. Iterate with the user until reaching an acceptable result.
+   - These queries and details will also be added to EXPLANATION.md
+
+### Step 3 - Design the policy definition
+
+Now that you have a working ARG query, work with the user to create a Policy Definition utilizing the external evaluation feature.
+Note that this skill is meant to help utilizing the new external evaluation feature, it's not a generic policy authoring skill. Also remember that the external evaluation feature is not publicly documented yet. This means that:
+- You must follow the canonical policy definition shape in `knowledge/02-policy-artifacts-shape.md` to ensure proper use of the new primitives and maximize your chances to create a working policy.
+- When it comes to the core evaluation logic, you should rely heavily on the user's input. If the user seems to be well versed in Azure Policy, your role should become helping them plug in the external evaluation endpoint definition and claims usage.
+
+1. Start with crafting the policy rule's `if` condition based on the input you received so far. The condition should capture both the applicability of the policy (e.g. `type == vm && tags[env] == prod`) as well as claims assertions (e.g. `coalesce(claims().otherSubnetsCount, null()) > 0`). Follow the shape described in `knowledge/02-policy-artifacts-shape.md`.
+2. Share the `if` condition with the user. Explain in words what the condition is doing. The verbal description of the condition should loosely match the policy intent one-liner you came up with in step 1. Answer any questions the user has about the claims() usage. Remember to anchor your responses with references to your knowledge base. Iterate with the user until reaching an acceptable result.
+3. Craft the `then` block. `effect` is always `[parameters('effect')]`. **If the effect family is action-time (`auditAction` / `denyAction`), also include `then.details.actionNames`** — the engine rejects the assignment otherwise. See `knowledge/02-policy-artifacts-shape.md` → `policyRule.then.details` for the exact shape.
+4. Craft the `externalEvaluationEnforcementSettings` section based on the canonical definition shape and the query you constructed in the previous stage. Take the query with the hard-coded values and replace it with an ARM template expression that formats the query at runtime, using `field()` / `parameters()` calls for the dynamic values. Escape every quote in the inner KQL.
+
+    Before (literal query, hard-coded NSG and subnet ids):
+
+    ```kusto
+    resources
+    | where type =~ "microsoft.network/networksecuritygroups"
+    | where id == "<NSG id being attached>"
+    | mv-expand subnet = properties["subnets"]
+    | where isnotnull(subnet["id"])
+    | where subnet["id"] !~ "<subnet id being modified>"
+    | summarize otherSubnetsCount = count()
+    ```
+
+    After (ARM template expression, single-line, all inner quotes escaped):
+
+    ```jsonc
+    "query": "[format('resources | where type =~ \"microsoft.network/networksecuritygroups\" | where id == \"{0}\" | mv-expand subnet = properties[\"subnets\"] | where isnotnull(subnet[\"id\"]) | where subnet[\"id\"] !~ \"{1}\" | summarize otherSubnetsCount = count()', field('Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id'), field('id'))]"
+    ```
+
+5. Share this section with the user. Explain what each part is doing and how you transformed the query and why. Iterate with the user until reaching an acceptable result.
+
+### Step 4 — Emit artifacts
+
+Before writing anything, tell the user — in one short line each — which files you're about to create and what each is for. Then write them.
+
+Create a new folder named after the policy (kebab-case, prefixed with `audit-` / `deny-` / `auditaction-` / `denyaction-`) and write three files:
+
+- `policy-definition.json` — model the canonical shape in `knowledge/02-policy-artifacts-shape.md` and the worked examples under `examples/`. Fill in the effect family from step 1, the target resource type, the claim name, and the `[format(...)]` KQL from step 2. The shape doc is authoritative for every field.
+- `test-flow.http` — start from `templates/test-flow.template.http`. Substitute the concrete RP path, API version, location, and request body. Keep the `### Expected:` lines. The policy assignment body is inlined inside this file rather than living in its own JSON — the REST Client extension does not expand `@`-variables inside files included via `< ./file.json`, so an external assignment file would emit a broken request.
+  - **Before each `acquirePolicyToken` POST, include a direct ARG query that mirrors what the policy will run for that case.** Build it from the same materialized KQL with the same inputs the policy will substitute (resource id, parameter values). Lets the user — and the agent, on a failing case — distinguish a wrong query from a policy/token/wiring problem in one extra send. See `examples/03-denyaction-actiongroup-in-use/test-flow.http` for the pattern.
+- `EXPLANATION.md` — three sections:
+  1. **What this policy does** — intent, target operation, bad-state condition, what gets denied vs allowed.
+  2. **Test queries used during co-design** — for each iteration of the KQL loop: the materialized query, the inputs, the actual ARG result, the conclusion.
+  3. **How to test this** — concrete steps for Portal, Azure CLI, and the `.http` file.
+
+Authoring rules for these files:
+
+- **No real environment values.** Subscription ids, resource group names, tenant ids, and specific resource names from the user's environment must be replaced with placeholders like `<subId>`, `<rgName>`, `<nsgName>` (or a generic-looking default like `nsg-immutable-test`) in *every* file you emit, including KQL examples quoted inside `EXPLANATION.md`. These bundles are shared publicly.
+- **Cross-references stay inside the bundle.** When `EXPLANATION.md` links to a knowledge file or another example, use a relative path inside this bundle (e.g. `../../knowledge/01-overview.md`). Do not invent absolute paths under `.copilot/skills/...` or any other deploy-time location — those won't resolve for the reader.
+
+Once the files are written, respond with a short message: list the files you created, point the user at `EXPLANATION.md` for the design walkthrough and at `test-flow.http` for the end-to-end create-and-test flow, and invite follow-ups. Do **not** re-explain what the policy does or restate each design decision — that's what `EXPLANATION.md` is for.
+
+---
+
+## When asked "why X?"
+
+Cite the relevant knowledge file and answer in one or two sentences. If the answer involves a trade-off (`missingTokenAction`, `mode: Indexed` vs `All`, `queryWithUserIdentity`), state the trade, the default, and offer to change it. If you don't have a citation, say so — don't invent one.
+
+---
+
+## When to stop
+
+If you discover mid-flow that the ask hits a limit you missed in step 1 — cross-sub query, request-mutation effect, data not in ARG, an invariant that won't collapse to one claim, or an unsupported endpoint kind — stop and explain. Don't write artifacts you know won't work. Suggest the nearest workable alternative (classic policy, DeployIfNotExists, a pipeline check) if one exists.
+
+Push back, but proceed after re-confirmation, when the user picks an effect from the wrong family for their operation kind (e.g. `denyAction` on a PUT, `deny` on a DELETE). The wrong family silently no-ops at runtime — the test loop appears to succeed and the customer thinks they have protection.
+
+---
+
+## Output style
+
+- Lead with the punchline. Use matter-of-fact and neutral tone. Be concise. Use plain language.
+- Show the materialized KQL (literal values substituted) — not the `[format(...)]` wrapper. That's the form that matters for debugging.
+- After each emitted artifact, a short `_why:_` callout listing the 3–6 most surprising choices with a pointer to the relevant knowledge file.
+- One concrete suggestion, not a list of options.

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/01-deny-nsg-overshared/EXPLANATION.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/01-deny-nsg-overshared/EXPLANATION.md
@@ -1,0 +1,76 @@
+# Explanation — Example 01: deny NSG over-sharing
+
+## 1. What this policy does
+
+When someone tries to attach an NSG to a subnet (PUT on `Microsoft.Network/virtualNetworks/subnets`), the policy asks ARG: "is this NSG already attached to any other subnet in this subscription?" If yes, the request is denied.
+
+The query pivots on the NSG (not the subnet): it loads the NSG by id, expands `properties.subnets`, drops the subnet being modified, counts what's left, and projects the count as `otherSubnetsCount`.
+
+What is and isn't denied:
+- Attaching an NSG that's already on ≥ 1 other subnet → denied (`otherSubnetsCount > 0`).
+- Attaching an NSG that's on no other subnet → allowed (`otherSubnetsCount == 0`).
+- A subnet PATCH that doesn't set `networkSecurityGroup.id` → short-circuits on the `notEquals: ""` filter and never hits ARG.
+- Attaching across subscriptions → not evaluated. External Evaluation is single-subscription scoped.
+
+## 2. Test queries used during co-design
+
+The KQL below was materialized and run via `az graph query -q "<query>" --subscriptions <sub>` while authoring the policy.
+
+### Iteration 1 — list subnets currently attached to a given NSG
+
+```kusto
+resources
+| where type =~ "microsoft.network/networksecuritygroups"
+| where id == "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/networkSecurityGroups/nsgA"
+| mv-expand subnet = properties["subnets"]
+| project subnetId = subnet["id"]
+```
+
+Confirms NSG rows in ARG carry the subnet associations as a `properties.subnets` array, and that `mv-expand` over it produces one row per attached subnet with `subnet["id"]` as the subnet's resource id.
+
+### Iteration 2 — exclude the subnet being modified, count
+
+```kusto
+resources
+| where type =~ "microsoft.network/networksecuritygroups"
+| where id == "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/networkSecurityGroups/nsgA"
+| mv-expand subnet = properties["subnets"]
+| where isnotnull(subnet["id"])
+| where subnet["id"] !~ "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/subnetB"
+| summarize otherSubnetsCount = count()
+```
+
+Input: NSG A attached to subnetA. Simulate the PUT that would attach it to subnetB. Expected: 1 row with `otherSubnetsCount = 1`. Matched.
+
+### Iteration 3 — 0-row sanity check (fresh NSG)
+
+Same query with a freshly-created NSG (NSG B) attached to nothing. Expected: 1 row with `otherSubnetsCount = 0`. `mv-expand` over an empty array produces 0 rows, but `summarize count()` without `by` always emits exactly one row, so the count is `0` rather than missing. Matched. The policy rule's `{ "value": "[claims().otherSubnetsCount]", "greater": 0 }` evaluates to false → request allowed.
+
+### From plain KQL to policy form
+
+The two literal id values become `field(...)` calls; the whole string is wrapped in `[format(...)]`:
+
+```kusto
+[format(
+  'resources
+   | where type =~ "microsoft.network/networksecuritygroups"
+   | where id == "{0}"
+   | mv-expand subnet = properties["subnets"]
+   | where isnotnull(subnet["id"])
+   | where subnet["id"] !~ "{1}"
+   | summarize otherSubnetsCount = count()',
+  field('Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id'),
+  field('id'))]
+```
+
+`field('…/networkSecurityGroup.id')` resolves against `operation.content.properties.networkSecurityGroup.id` at token-acquisition time — that's the NSG id being attached. `field('id')` is the subnet's own id, excluded so the count counts *other* subnets only.
+
+## 3. How to test
+
+Open `test-flow.http` in VS Code with the REST Client extension, edit the variables at the top, and send the requests top to bottom. The flow walks: resource group → vnet with 2 subnets (A, B) → NSG A → attach NSG A to subnetA → NSG B → policy definition → policy assignment → unauth PUT NSG A → subnetB (deny) → acquire-token for that op (denied, no token) → unauth PUT NSG B → subnetB (deny) → acquire-token for NSG B → subnetB (allowed, token returned) → retry NSG B → subnetB with the token (succeeds). Interleaved `GET` requests after each `PUT` let you eyeball the resource before moving on.
+
+No role-assignment step: the definition sets `queryWithUserIdentity: true`, so the assignment's MSI isn't used at ARG-call time. The caller's bearer (`{{tok}}`) needs Reader on the resources the query reads.
+
+The policy assignment body is embedded inline in `test-flow.http` rather than living in its own JSON file — the REST Client extension doesn't expand `@`-variables inside files included via `< ./file.json`, so an external assignment file would PUT a request with literal `{{policyName}}` strings.
+
+The acquirePolicyToken body must mirror the guarded ARM PUT byte-for-byte, or the token won't bind. The token comes back with a `PoP ` prefix; pass it through verbatim including the prefix.

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/01-deny-nsg-overshared/README.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/01-deny-nsg-overshared/README.md
@@ -1,0 +1,46 @@
+# Example 01 — Deny NSG over-sharing
+
+## Intent
+
+Deny attaching a Network Security Group to a subnet if that same NSG is already attached to any other subnet in the same subscription.
+
+## Effect family
+
+PUT on `Microsoft.Network/virtualNetworks/subnets` → `deny` (parameterized; assignment sets `effect.value = "deny"`).
+
+## KQL — plain (what to test with `az graph query`)
+
+```kusto
+resources
+| where type =~ "microsoft.network/networksecuritygroups"
+| where id == "<NSG id being attached>"
+| mv-expand subnet = properties["subnets"]
+| where isnotnull(subnet["id"])
+| where subnet["id"] !~ "<subnet id being modified>"
+| summarize otherSubnetsCount = count()
+```
+
+The query pivots on the NSG: load the NSG by id, expand its `properties.subnets` array, drop the subnet currently being modified, and count what's left. `summarize` without `by` always emits exactly one row, so an NSG attached to nothing still produces `otherSubnetsCount = 0` (not a null/no-row claim).
+
+Expected results:
+- NSG already attached to ≥ 1 other subnet → `otherSubnetsCount > 0` → deny.
+- NSG attached to no other subnet → `otherSubnetsCount == 0` → allow.
+
+## KQL — policy form
+
+The two literal id values become `field(...)` calls; the whole string is wrapped in `[format(...)]`:
+
+```kusto
+[format(
+  'resources
+   | where type =~ "microsoft.network/networksecuritygroups"
+   | where id == "{0}"
+   | mv-expand subnet = properties["subnets"]
+   | where isnotnull(subnet["id"])
+   | where subnet["id"] !~ "{1}"
+   | summarize otherSubnetsCount = count()',
+  field('Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id'),
+  field('id'))]
+```
+
+`field('Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id')` resolves against the inbound subnet PUT body at token-acquisition time — that's the NSG id being attached. `field('id')` is the resource id of the subnet being modified, excluded so the count reflects *other* subnets only.

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/01-deny-nsg-overshared/policy-definition.json
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/01-deny-nsg-overshared/policy-definition.json
@@ -1,0 +1,54 @@
+{
+  "properties": {
+    "displayName": "Deny attaching an NSG to subnet if the NSG is already attached to a different subnet",
+    "description": "Denies attaching a Network Security Group to a subnet when the same NSG is already attached to a different subnet in the subscription. Triggers on subnet PUT/PATCH operations that set a networkSecurityGroup reference; subnet operations without an NSG reference, and unrelated NSG updates, are unaffected.",
+    "policyType": "Custom",
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": { "displayName": "Effect" },
+        "allowedValues": [ "audit", "deny", "disabled" ],
+        "defaultValue": "audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/virtualNetworks/subnets"
+          },
+          {
+            "field": "Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id",
+            "notEquals": ""
+          },
+          {
+            "value": "[claims().otherSubnetsCount]",
+            "greater": 0
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    },
+    "externalEvaluationEnforcementSettings": {
+      "missingTokenAction": "deny",
+      "resultLifespan": "PT1H",
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+      ],
+      "endpointSettings": {
+        "kind": "AzureResourceGraph",
+        "details": {
+          "query": "[format('resources | where type =~ \"microsoft.network/networksecuritygroups\" | where id == \"{0}\" | mv-expand subnet = properties[\"subnets\"] | where isnotnull(subnet[\"id\"]) | where subnet[\"id\"] !~ \"{1}\" | summarize otherSubnetsCount = count()', field('Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id'), field('id'))]",
+          "queryProjectedClaims": [
+            "otherSubnetsCount"
+          ],
+          "queryWithUserIdentity": true
+        }
+      }
+    }
+  }
+}

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/01-deny-nsg-overshared/test-flow.http
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/01-deny-nsg-overshared/test-flow.http
@@ -1,0 +1,286 @@
+# test-flow.http — Example 01: deny NSG over-sharing.
+# Replace the @-variables, then send requests in order.
+
+### Variables
+
+# User auth token with the "Bearer" prefix. Can be acquired via `armclient token` (requires http://aka.ms/armclient)
+@tok = Bearer <token>
+@host = https://management.azure.com
+@subId = <your-subscription-id>
+@rgName = <your-resource-group-name>
+@vnetName = vnet
+@nsgNamePrefix = nsg
+@policyName = deny-nsg-overshared
+@argApiVersion = 2022-10-01
+
+###############################################################################
+### 1. Create resource group
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}?api-version=2021-04-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "location": "eastus"
+}
+
+###############################################################################
+### 2. Create VNet with 2 subnets
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}?api-version=2025-03-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "name": "{{vnetName}}",
+  "location": "eastus",
+  "properties": {
+    "addressSpace": { "addressPrefixes": [ "172.16.0.0/16" ] },
+    "subnets": [
+      { "name": "subnetA", "properties": { "addressPrefix": "172.16.1.0/24" } },
+      { "name": "subnetB", "properties": { "addressPrefix": "172.16.2.0/24" } }
+    ]
+  }
+}
+
+###############################################################################
+### 2.1 Get the VNet
+###############################################################################
+GET {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}?api-version=2025-03-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+
+###############################################################################
+### 3. Create NSG A
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}A?api-version=2025-03-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "name": "{{nsgNamePrefix}}A",
+  "location": "eastus",
+  "properties": { "securityRules": [] }
+}
+
+###############################################################################
+### 3.1 Get NSG A
+###############################################################################
+GET {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}A?api-version=2025-03-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+###############################################################################
+### 4. Attach NSG A to subnetA
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetA?api-version=2025-03-01
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "name": "subnetA",
+  "location": "eastus",
+  "properties": {
+    "addressPrefix": "172.16.1.0/24",
+    "networkSecurityGroup": { "id": "/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}A" }
+  }
+}
+
+###############################################################################
+### 4.1 Get subnetA
+###############################################################################
+GET {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetA?api-version=2025-03-01
+Authorization: {{tok}}
+Content-Type: application/json
+
+
+###############################################################################
+### 5. Create NSG B
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}B?api-version=2025-03-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "name": "{{nsgNamePrefix}}B",
+  "location": "eastus",
+  "properties": { "securityRules": [] }
+}
+
+
+###############################################################################
+### 5.1 Get NSG B
+###############################################################################
+GET {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}B?api-version=2025-03-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+###############################################################################
+### 6. Create policy definition at the subscription scope
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{policyName}}?api-version=2025-03-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+< ./policy-definition.json
+
+###############################################################################
+### 7. Assign policy to the resource group
+###############################################################################
+# Body is inlined (rather than `< ./policy-assignment.json`) because the REST
+# Client extension does not expand @-variables inside files included via `<`.
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Authorization/policyAssignments/{{policyName}}?api-version=2025-03-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "properties": {
+    "displayName": "Assign — deny NSG over-sharing",
+    "policyDefinitionId": "/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{policyName}}",
+    "parameters": {
+      "effect": { "value": "deny" }
+    }
+  },
+  "name": "{{policyName}}",
+  "location": "eastus",
+  "identity": { "type": "systemassigned" }
+}
+
+### Note: queryWithUserIdentity: true is set on the definition, so the assignment's
+### MSI is not used at ARG-call time. No role-assignment step is needed — the caller's
+### identity (the {{tok}} bearer) needs Reader on the resources the query reads.
+
+###############################################################################
+### 8. Attempt to attach NSG A to subnetB without token — expect deny
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetB?api-version=2025-03-01
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "name": "subnetB",
+  "location": "eastus",
+  "properties": {
+    "addressPrefix": "172.16.2.0/24",
+    "networkSecurityGroup": { "id": "/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}A" }
+  }
+}
+
+### Expected: 403 RequestDisallowedByPolicy. The missingPolicyTokenDetails block carries endpoint metadata; the acquirePolicyToken URL is a constant ARM path (see step 9).
+
+###############################################################################
+### 9. Acquire token for attaching NSG A to subnetB — expect deny, no token
+###############################################################################
+
+### Preview the ARG query the policy will run for this case — expect otherSubnetsCount: 1
+### (subnetA still uses NSG A, so attaching NSG A to subnetB is over-sharing).
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type =~ 'microsoft.network/networksecuritygroups' | where id == '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}A' | mv-expand subnet = properties['subnets'] | where isnotnull(subnet['id']) | where subnet['id'] !~ '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetB' | summarize otherSubnetsCount = count()"
+}
+
+### Expected: .data[0].otherSubnetsCount == 1.
+
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version=2025-11-01
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetB?api-version=2024-07-01",
+    "httpMethod": "PUT",
+    "content": {
+      "name": "subnetB",
+      "location": "eastus",
+      "properties": {
+        "addressPrefix": "172.16.2.0/24",
+        "networkSecurityGroup": { "id": "/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}A" }
+      }
+    }
+  }
+}
+
+### Expected: 200 with results[0].policyAction == "Deny" and no token field. claims.otherSubnetsCount > 0 (NSG A is on subnetA already).
+
+###############################################################################
+### 10. Attempt to attach NSG B to subnetB without token — expect deny
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetB?api-version=2025-03-01
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "name": "subnetB",
+  "location": "eastus",
+  "properties": {
+    "addressPrefix": "172.16.2.0/24",
+    "networkSecurityGroup": { "id": "/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}B" }
+  }
+}
+
+### Expected: 403 RequestDisallowedByPolicy (no token attached yet).
+
+###############################################################################
+### 11. Acquire token for attaching NSG B to subnetB — expect allow + token
+###############################################################################
+
+### Preview the ARG query for this case — expect otherSubnetsCount: 0
+### (NSG B is fresh, not on any subnet → not over-sharing).
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type =~ 'microsoft.network/networksecuritygroups' | where id == '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}B' | mv-expand subnet = properties['subnets'] | where isnotnull(subnet['id']) | where subnet['id'] !~ '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetB' | summarize otherSubnetsCount = count()"
+}
+
+### Expected: .data[0].otherSubnetsCount == 0.
+
+# @name token
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version=2025-11-01
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetB?api-version=2024-07-01",
+    "httpMethod": "PUT",
+    "content": {
+      "name": "subnetB",
+      "location": "eastus",
+      "properties": {
+        "addressPrefix": "172.16.2.0/24",
+        "networkSecurityGroup": { "id": "/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}B" }
+      }
+    }
+  }
+}
+
+### Expected: 200 with results[0].policyAction == "Allow" and a token field prefixed "PoP ". claims.otherSubnetsCount == 0 (NSG B is on no other subnet).
+
+###############################################################################
+### 12. Attach NSG B to subnetB with token — expect success
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/virtualNetworks/{{vnetName}}/subnets/subnetB?api-version=2025-03-01
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-policy-external-evaluations: {{token.response.body.$.token}}
+
+{
+  "name": "subnetB",
+  "location": "eastus",
+  "properties": {
+    "addressPrefix": "172.16.2.0/24",
+    "networkSecurityGroup": { "id": "/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgNamePrefix}}B" }
+  }
+}
+
+### Expected: subnet PUT succeeds.

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/02-deny-immutable-tag-on-nsg/EXPLANATION.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/02-deny-immutable-tag-on-nsg/EXPLANATION.md
@@ -1,0 +1,127 @@
+# Explanation — Deny changing or removing an immutable tag on an NSG
+
+## 1. What this policy does
+
+When someone issues a PUT/PATCH against an `Microsoft.Network/networkSecurityGroups` resource, the policy asks ARG: "does this NSG already exist with the named tag set, AND is the incoming request changing or clearing that tag?" If yes, the request is denied.
+
+The query loads the NSG by id, reads the current value of the parameterized tag, and projects a single boolean `isImmutableViolation` computed as `existingTag is not empty AND existingTag != incomingTag`. The `incomingTag` value is plugged into the query at token-acquisition time from the request body via a dynamic `field()` lookup; an absent tag in the body is coalesced to `""`, which is what makes "delete the tag" register as a violation.
+
+What is and isn't denied:
+
+- New NSG (no row in ARG yet) → ARG returns 0 rows → claim is null → `bool(coalesce(claim, false()))` → `false` → policy allows.
+- Existing NSG that doesn't yet have the tag → `isnotempty(existingTag) == false` → `isImmutableViolation = false` → allowed. Adding the tag is fine.
+- Existing NSG with the tag, request keeps the same value → `existingTag == incomingTag` → `false` → allowed.
+- Existing NSG with the tag, request changes the value → `true` → **denied**.
+- Existing NSG with the tag, request omits the tag → `incomingTag` coalesces to `""`, `existingTag != ""` → `true` → **denied**.
+- Tag updates via `Microsoft.Resources/tags` (the tags-as-a-resource API used by `az tag update` and currently by the Portal's tag editor) → not evaluated. See `knowledge/01-overview.md` under "Known issues" for details and tracking.
+- Cross-subscription anything → not evaluated. External Evaluation is single-subscription scoped.
+
+### Known caveat: ARG eventual consistency
+
+ARG is the standard product and refreshes asynchronously. If a user sets the tag and immediately attempts to change it within the lag window (typically seconds, occasionally longer), ARG may not yet show the original tag — `existingTag` will be empty, the policy will see "no immutability to protect", and the change will be allowed. There is no in-policy mitigation. Same caveat applies in reverse for newly-created NSGs: the policy never blocks the first PUT that sets the tag (correctly), but a near-immediate second PUT changing it could slip through.
+
+## 2. Test queries used during co-design
+
+All queries below were materialized and run via `az graph query -q "<query>"` against a sample NSG that carries `immutableIdentifier = "123"`.
+
+### Q0 — Sanity: confirm the NSG and read its current tag value
+
+```kusto
+resources
+| where type =~ "microsoft.network/networksecuritygroups"
+| where id =~ "/subscriptions/<subId>/resourceGroups/<rgName>/providers/Microsoft.Network/networkSecurityGroups/<nsgName>"
+| project id, tags
+```
+
+Result: 1 row, `tags.immutableIdentifier == "123"`. Confirms tag-name spelling and that ARG carries NSG tags under `tags.<name>`.
+
+### Q1 — Existing tag, incoming SAME value (must allow)
+
+```kusto
+resources
+| where type =~ "microsoft.network/networksecuritygroups"
+| where id =~ "/subscriptions/<subId>/resourceGroups/<rgName>/providers/Microsoft.Network/networkSecurityGroups/<nsgName>"
+| extend existingTag = tostring(tags["immutableIdentifier"])
+| project isImmutableViolation = isnotempty(existingTag) and existingTag != "123"
+```
+
+Result: `isImmutableViolation = 0` (false). ✅
+
+### Q2 — Existing tag, incoming DIFFERENT value (must deny)
+
+Same as Q1 with `"123"` → `"456"`. Result: `isImmutableViolation = 1` (true). ✅
+
+### Q3 — Existing tag, incoming MISSING/EMPTY (must deny — covers the "delete the tag" case)
+
+Same as Q1 with `"123"` → `""`. Result: `isImmutableViolation = 1` (true). ✅ This is why the `[format(...)]` expression in the policy uses `coalesce(field('tags[...]'), '')` for the incoming value — an absent tag in the request body becomes `""` and trips this exact branch.
+
+### Q4 — NSG not in ARG yet (simulates new-resource creation, must allow)
+
+Same query with a non-existent NSG id. Result: `0 rows`. The projected claim is therefore null, and the policy's `[bool(coalesce(claims().isImmutableViolation, false()))]` evaluates to `false` so the rule does not fire. ✅
+
+### From plain KQL to policy form
+
+Three runtime values become substitutions; the whole string is wrapped in `[format(...)]`:
+
+```kusto
+[format(
+  'resources
+   | where type =~ "microsoft.network/networksecuritygroups"
+   | where id =~ "{0}"
+   | extend existingTag = tostring(tags["{1}"])
+   | project isImmutableViolation = isnotempty(existingTag) and existingTag != "{2}"',
+  field('id'),
+  parameters('tagName'),
+  coalesce(field(concat('tags[', parameters('tagName'), ']')), ''))]
+```
+
+- `{0}` ← `field('id')` — the NSG's resource id from the incoming PUT/PATCH. Filters ARG to a single row, satisfying the endpoint's 0-or-1-row requirement.
+- `{1}` ← `parameters('tagName')` — the tag name from the policy parameter. Lets one definition serve as the template for many assignments, each enforcing a different tag.
+- `{2}` ← `coalesce(field(concat('tags[', parameters('tagName'), ']')), '')` — the incoming tag value from the request body, defaulted to `""` when the tag is absent. Empty string is the sentinel that turns "the user is trying to remove this tag" into a violation in the `existingTag != ""` clause.
+
+## 3. How to test
+
+Three options:
+
+### Option A — VS Code REST Client (the `.http` file)
+
+Open `test-flow.http` in VS Code with the REST Client extension, edit the variables at the top (`@tok`, `@subId`, `@rgName`), and send the requests top to bottom. The flow walks:
+
+1. Resource group → policy definition → policy assignment.
+2. **Case A**: create an NSG without the tag. First PUT without a token → 403. Acquire token (Allow, null claim) → retry PUT → 200.
+3. **Case B**: PUT the same NSG adding the tag for the first time. Token → Allow (`isImmutableViolation = false`) → PUT → 200.
+4. **Case C**: same-value re-PUT. Token → Allow.
+5. **Case D**: PUT with a different tag value. Token → **Deny**, no token returned.
+6. **Case E**: PUT omitting the tag. Token → **Deny**.
+7. **Case F**: direct PUT (no token) attempting the change → 403.
+
+Cases B and C require waiting for ARG eventual consistency after the prior PUT.
+
+No role-assignment step is needed: the definition sets `queryWithUserIdentity: true`, so the assignment's MSI is not used at ARG-call time. The caller's bearer (`{{tok}}`) needs Reader on the NSG, which any caller authorized to PUT it already has.
+
+### Option B — Azure CLI
+
+```bash
+# Setup
+az policy definition create --name deny-immutable-tag-on-nsg --rules @policy-definition.json --mode All --subscription <subId>
+az policy assignment create --name deny-immutable-tag-on-nsg \
+  --policy deny-immutable-tag-on-nsg \
+  --scope /subscriptions/<subId>/resourceGroups/<rg> \
+  --params '{"effect":{"value":"deny"},"tagName":{"value":"immutableIdentifier"}}' \
+  --location eastus --mi-system-assigned
+
+# Create NSG without the tag — needs --acquire-policy-token because missingTokenAction=deny.
+az network nsg create -g <rg> -n nsg-immutable-test --acquire-policy-token
+
+# Add the tag — allowed.
+az network nsg update -g <rg> -n nsg-immutable-test --set tags.immutableIdentifier=123 --acquire-policy-token
+
+# Wait a few seconds for ARG consistency, then attempt to change — should fail.
+az network nsg update -g <rg> -n nsg-immutable-test --set tags.immutableIdentifier=456 --acquire-policy-token
+```
+
+The last command should fail with `RequestDisallowedByPolicy`. `--acquire-policy-token` is the global flag added in Azure CLI 2.85.0 (see `../../knowledge/01-overview.md`).
+
+### Option C — Azure Portal
+
+Portal intercepts missing-token failures, calls `acquirePolicyToken`, and retries automatically. Open the NSG, edit the tag, save. If the change is allowed it goes through transparently; if denied you'll see a 403 surfaced as a tooltip referencing the policy assignment.

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/02-deny-immutable-tag-on-nsg/policy-definition.json
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/02-deny-immutable-tag-on-nsg/policy-definition.json
@@ -1,0 +1,57 @@
+{
+  "properties": {
+    "displayName": "Deny changing or removing an immutable tag on an NSG",
+    "description": "Once a Network Security Group has the specified tag set, the policy denies any PUT/PATCH that changes the tag's value or removes it. New NSGs created without the tag are allowed, as are updates to existing NSGs that don't yet carry the tag.",
+    "policyType": "Custom",
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": { "displayName": "Effect" },
+        "allowedValues": [ "audit", "deny", "disabled" ],
+        "defaultValue": "audit"
+      },
+      "tagName": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Tag name",
+          "description": "The tag whose value must remain immutable once set on the NSG."
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/networkSecurityGroups"
+          },
+          {
+            "value": "[bool(coalesce(claims().isImmutableViolation, false()))]",
+            "equals": true
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    },
+    "externalEvaluationEnforcementSettings": {
+      "missingTokenAction": "deny",
+      "resultLifespan": "PT1H",
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+      ],
+      "endpointSettings": {
+        "kind": "AzureResourceGraph",
+        "details": {
+          "query": "[format('resources | where type =~ \"microsoft.network/networksecuritygroups\" | where id =~ \"{0}\" | extend existingTag = tostring(tags[\"{1}\"]) | project isImmutableViolation = isnotempty(existingTag) and existingTag != \"{2}\"', field('id'), parameters('tagName'), coalesce(field(concat('tags[', parameters('tagName'), ']')), ''))]",
+          "queryProjectedClaims": [
+            "isImmutableViolation"
+          ],
+          "queryWithUserIdentity": true
+        }
+      }
+    }
+  }
+}

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/02-deny-immutable-tag-on-nsg/test-flow.http
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/02-deny-immutable-tag-on-nsg/test-flow.http
@@ -1,0 +1,315 @@
+# test-flow.http — Deny changing or removing an immutable tag on an NSG.
+# Replace the @-variables below, then send requests in order.
+
+### Variables
+
+# User auth token with the "Bearer " prefix. Acquire via `armclient token` (http://aka.ms/armclient).
+@tok = Bearer <token>
+@host = https://management.azure.com
+@subId = <your-subscription-id>
+@rgName = <your-resource-group-name>
+@nsgName = nsg-immutable-test
+@tagName = immutableIdentifier
+@tagValueOriginal = 123
+@tagValueDifferent = 456
+@policyName = deny-immutable-tag-on-nsg
+@apiVersion = 2025-03-01
+@tokenApiVersion = 2025-11-01
+@argApiVersion = 2022-10-01
+
+###############################################################################
+### 1. Create resource group
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}?api-version=2021-04-01
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "location": "eastus"
+}
+
+###############################################################################
+### 2. Create policy definition at the subscription scope
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{policyName}}?api-version={{apiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+< ./policy-definition.json
+
+###############################################################################
+### 3. Assign policy to the resource group
+###############################################################################
+# Body is inlined (rather than `< ./policy-assignment.json`) because the REST
+# Client extension does not expand @-variables inside files included via `<`.
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Authorization/policyAssignments/{{policyName}}?api-version={{apiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "properties": {
+    "displayName": "Assign — deny immutable tag changes on NSG",
+    "policyDefinitionId": "/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{policyName}}",
+    "parameters": {
+      "effect":  { "value": "deny" },
+      "tagName": { "value": "{{tagName}}" }
+    }
+  },
+  "name": "{{policyName}}",
+  "location": "eastus",
+  "identity": { "type": "systemassigned" }
+}
+
+### Note: queryWithUserIdentity: true is set on the definition, so the assignment's
+### MSI is not used at ARG-call time. The caller's identity ({{tok}}) needs Reader on
+### the NSG the query reads.
+
+###############################################################################
+### 4. CASE A — Create a new NSG WITHOUT the immutable tag.
+###    Expect: allowed. The NSG isn't in ARG yet → 0 rows → null claim →
+###    coalesce → false → policy doesn't fire.
+###############################################################################
+
+###############################################################################
+### 4.1 First PUT without a token — expect 403 (missingTokenAction: deny)
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "location": "eastus",
+  "properties": { "securityRules": [] }
+}
+
+### Expected: 403 RequestDisallowedByPolicy.
+
+###############################################################################
+### 4.2 Acquire token for creating the NSG without tag — expect Allow + token
+###############################################################################
+
+### Preview the ARG query the policy will run for this case — expect 0 rows
+### (NSG not in ARG yet → claim is null → coalesce → false → policy doesn't fire).
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type =~ 'microsoft.network/networksecuritygroups' | where id =~ '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}' | extend existingTag = tostring(tags['{{tagName}}']) | project isImmutableViolation = isnotempty(existingTag) and existingTag != ''"
+}
+
+### Expected: .data is empty (NSG not yet in ARG). At policy-eval time the
+### claim will be null; the policyRule coalesces it to false → allow.
+
+# @name tokenCreateNoTag
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}",
+    "httpMethod": "PUT",
+    "content": {
+      "location": "eastus",
+      "properties": { "securityRules": [] }
+    }
+  }
+}
+
+### Expected: 200 with .results[0].policyAction == "Allow" and a token prefixed "PoP ".
+###           .results[0].claims.isImmutableViolation is null (NSG not in ARG yet).
+
+###############################################################################
+### 4.3 Retry the PUT with the token — expect success
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+x-ms-policy-external-evaluations: {{tokenCreateNoTag.response.body.$.token}}
+
+{
+  "location": "eastus",
+  "properties": { "securityRules": [] }
+}
+
+### Expected: 200/201. NSG created. Wait for ARG eventual consistency before next step.
+
+###############################################################################
+### 5. CASE B — Add the immutable tag for the first time on the existing NSG.
+###    Expect: allowed. ARG row exists but existingTag is empty → false → allow.
+###############################################################################
+
+### Preview the ARG query for this case — expect isImmutableViolation: false
+### (NSG row exists with no tag → existingTag empty → isnotempty=false).
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type =~ 'microsoft.network/networksecuritygroups' | where id =~ '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}' | extend existingTag = tostring(tags['{{tagName}}']) | project isImmutableViolation = isnotempty(existingTag) and existingTag != '{{tagValueOriginal}}'"
+}
+
+### Expected: .data[0].isImmutableViolation == false (or 0).
+
+# @name tokenAddTag
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}",
+    "httpMethod": "PUT",
+    "content": {
+      "location": "eastus",
+      "tags": { "{{tagName}}": "{{tagValueOriginal}}" },
+      "properties": { "securityRules": [] }
+    }
+  }
+}
+
+### Expected: Allow + token. claims.isImmutableViolation == false.
+
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+x-ms-policy-external-evaluations: {{tokenAddTag.response.body.$.token}}
+
+{
+  "location": "eastus",
+  "tags": { "{{tagName}}": "{{tagValueOriginal}}" },
+  "properties": { "securityRules": [] }
+}
+
+### Expected: 200. NSG now has immutableIdentifier=123. Wait for ARG consistency.
+
+###############################################################################
+### 6. CASE C — Same value re-PUT (idempotent). Expect: allowed.
+###############################################################################
+
+### Preview the ARG query for this case — expect isImmutableViolation: false
+### (existingTag == incoming value → not a violation).
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type =~ 'microsoft.network/networksecuritygroups' | where id =~ '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}' | extend existingTag = tostring(tags['{{tagName}}']) | project isImmutableViolation = isnotempty(existingTag) and existingTag != '{{tagValueOriginal}}'"
+}
+
+### Expected: .data[0].isImmutableViolation == false.
+
+# @name tokenSameValue
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}",
+    "httpMethod": "PUT",
+    "content": {
+      "location": "eastus",
+      "tags": { "{{tagName}}": "{{tagValueOriginal}}" },
+      "properties": { "securityRules": [] }
+    }
+  }
+}
+
+### Expected: Allow + token. existingTag == incoming → not a violation.
+
+###############################################################################
+### 7. CASE D — Attempt to CHANGE the tag value. Expect: denied, no token.
+###############################################################################
+
+### Preview the ARG query for this case — expect isImmutableViolation: true
+### (existingTag '{{tagValueOriginal}}' != incoming '{{tagValueDifferent}}').
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type =~ 'microsoft.network/networksecuritygroups' | where id =~ '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}' | extend existingTag = tostring(tags['{{tagName}}']) | project isImmutableViolation = isnotempty(existingTag) and existingTag != '{{tagValueDifferent}}'"
+}
+
+### Expected: .data[0].isImmutableViolation == true (or 1).
+
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}",
+    "httpMethod": "PUT",
+    "content": {
+      "location": "eastus",
+      "tags": { "{{tagName}}": "{{tagValueDifferent}}" },
+      "properties": { "securityRules": [] }
+    }
+  }
+}
+
+### Expected: 200 with .results[0].policyAction == "Deny" and no token.
+###           claims.isImmutableViolation == true.
+
+###############################################################################
+### 8. CASE E — Attempt to REMOVE the tag entirely. Expect: denied.
+###############################################################################
+
+### Preview the ARG query for this case — expect isImmutableViolation: true.
+### The policy coalesces the missing incoming tag to '' so the materialized
+### KQL compares existingTag ('{{tagValueOriginal}}') against the empty string.
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type =~ 'microsoft.network/networksecuritygroups' | where id =~ '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}' | extend existingTag = tostring(tags['{{tagName}}']) | project isImmutableViolation = isnotempty(existingTag) and existingTag != ''"
+}
+
+### Expected: .data[0].isImmutableViolation == true.
+
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}",
+    "httpMethod": "PUT",
+    "content": {
+      "location": "eastus",
+      "properties": { "securityRules": [] }
+    }
+  }
+}
+
+### Expected: 200 with .results[0].policyAction == "Deny" and no token.
+###           Incoming tag value coalesces to "" → existingTag ("123") != "" → violation.
+
+###############################################################################
+### 9. CASE F — Direct PUT without token attempting the change — expect 403.
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Network/networkSecurityGroups/{{nsgName}}?api-version={{apiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "location": "eastus",
+  "tags": { "{{tagName}}": "{{tagValueDifferent}}" },
+  "properties": { "securityRules": [] }
+}
+
+### Expected: 403 RequestDisallowedByPolicy.

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/03-denyaction-actiongroup-in-use/EXPLANATION.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/03-denyaction-actiongroup-in-use/EXPLANATION.md
@@ -1,0 +1,134 @@
+# Block delete of an Action Group still referenced by alert rules
+
+## What this policy does
+
+**Intent.** Once an Action Group has any alert rule pointing at it, the policy denies any attempt to delete it. The Action Group must be unreferenced before it can be removed. New Action Groups are created freely; only DELETE is guarded.
+
+**Target operation.** `DELETE` on `Microsoft.Insights/actionGroups` (effect family: `auditAction` / `denyAction`).
+
+**Bad-state condition.** Any of the following resource types in the same subscription has a serialized `properties` blob containing the target Action Group's resource ID:
+
+- `Microsoft.Insights/metricAlerts` (`properties.actions[].actionGroupId`)
+- `Microsoft.Insights/scheduledQueryRules` (`properties.actions.actionGroups[]`)
+- `Microsoft.Insights/activityLogAlerts` (`properties.actions.actionGroups[].actionGroupId`)
+
+The three alert types each store the reference at a slightly different JSON path. The KQL avoids per-type unpacking by serializing `properties` and substring-matching the action-group resource ID — which is a unique, fully-qualified ARM ID, so false positives are not a practical concern.
+
+**Allowed.** Creating Action Groups; modifying them; deleting an Action Group that no alert rule references; deleting referencing alert rules (the policy only guards `Microsoft.Insights/actionGroups`).
+
+**Denied.** Deleting an Action Group while at least one alert rule still references it.
+
+### Customer value
+
+Deleting an Action Group silently succeeds in Azure today even when alerts reference it. The referencing alert rules keep firing — into a void — and the on-call rotation stops paging. This is a classic SRE incident pattern: someone "cleans up" stale-looking Action Groups during a refactor, and weeks later an outage isn't noticed because the page never went out. This policy is the guardrail for that pattern.
+
+### Scope notes / known gaps
+
+- **Smart Detector Alert Rules** (`microsoft.alertsmanagement/smartdetectoralertrules`) and **Alert Processing Rules** (`microsoft.alertsmanagement/actionrules`) are not scanned. They are niche; extending the query to them is a one-line change to the `in~` list.
+- **Cross-subscription references** are not detected — External Evaluation pins the ARG call to the current subscription.
+- **ARG eventual consistency** — newly created or deleted alert rules may not appear in ARG for seconds to minutes. A freshly-deleted alert can briefly cause the policy to still deny the Action Group's deletion.
+
+---
+
+## Test queries used during co-design
+
+The KQL was developed and validated against a test subscription `<subId>` and resource group `<rgName>` with three resources created up front:
+
+| Resource | Type | Role in test |
+|---|---|---|
+| `ag-referenced` | `Microsoft.Insights/actionGroups` | Referenced by `alert-test` |
+| `ag-orphan` | `Microsoft.Insights/actionGroups` | Not referenced by anything |
+| `alert-test` | `Microsoft.Insights/activityLogAlerts` | References `ag-referenced` |
+
+### Query 1 — confirm the reference shape on activity log alerts
+
+Goal: pick a query strategy. Confirm where the action-group ID lives in the alert's `properties`.
+
+```kusto
+resources
+| where type =~ "microsoft.insights/activitylogalerts"
+| where id =~ "/subscriptions/<subId>/resourceGroups/<rgName>/providers/Microsoft.Insights/activityLogAlerts/alert-test"
+| project actions = properties.actions
+```
+
+Result:
+
+```json
+{ "actions": { "actionGroups": [ { "actionGroupId": "/subscriptions/.../actionGroups/ag-referenced" } ] } }
+```
+
+Conclusion: the reference is nested under `properties.actions.actionGroups[].actionGroupId` for activity log alerts. Metric alerts use `properties.actions[].actionGroupId`; scheduled query rules use `properties.actions.actionGroups[]` as a flat string array. To avoid per-type unpacking, the production query serializes the whole `properties` object and substring-matches the action-group's resource ID.
+
+### Query 2 — referenced AG (should be `true`)
+
+```kusto
+resources
+| where type in~ ("microsoft.insights/metricalerts","microsoft.insights/scheduledqueryrules","microsoft.insights/activitylogalerts")
+| where tostring(properties) contains "/subscriptions/<subId>/resourceGroups/<rgName>/providers/Microsoft.Insights/actionGroups/ag-referenced"
+| summarize refCount = count()
+| project isReferenced = refCount > 0
+```
+
+Result: `isReferenced = 1`. ✓
+
+### Query 3 — orphan AG (should be `false`)
+
+Same query, substituting `ag-orphan` for `ag-referenced`.
+
+Result: `isReferenced = 0`. ✓
+
+### Note on the int-vs-bool gotcha
+
+ARG serializes KQL booleans as integer `0`/`1` over the wire to Policy. The policy rule wraps the claim with `bool(...)` to coerce back to a boolean:
+
+```jsonc
+{ "value": "[bool(coalesce(claims().isReferenced, false()))]", "equals": true }
+```
+
+Without the `bool()` wrap, the condition silently never fires because `1 != true` under the policy engine's strict equality.
+
+---
+
+## How to test this
+
+### Prerequisites
+
+None — the `.http` file creates the resource group, the three test resources, the policy definition, and the assignment from scratch. You just need a bearer token (`armclient token`) and a subscription you can write to.
+
+### Option A — `.http` file (recommended)
+
+1. Install the "REST Client" VS Code extension.
+2. Open `test-flow.http`, replace `@tok` with your bearer token and `@subId` with your subscription.
+3. Send requests top-to-bottom. The file is self-contained: RG → 3 resources → policy def → assignment → test cases → cleanup.
+
+The flow covers:
+
+- **Case A** — DELETE `ag-orphan` → Allow (no references)
+- **Case B** — DELETE `ag-referenced` → Deny (alert-test references it)
+- **Case C** — Direct DELETE without token → 403
+- **Case D** — Delete `alert-test`, wait for ARG, then DELETE `ag-referenced` → Allow
+
+### Option B — Portal
+
+1. Run Steps 1–6 from `test-flow.http` to create the resources, definition, and assignment.
+2. In the Portal, navigate to the test RG → Action Groups → `ag-referenced` → Delete. Expect a policy-denied error.
+3. Try the same on `ag-orphan` — expect success.
+
+### Option C — Azure CLI
+
+```powershell
+# Requires Azure CLI 2.85.0+ for --acquire-policy-token
+
+# This should fail with a denyAction message.
+az monitor action-group delete --name ag-referenced --resource-group <rgName> --acquire-policy-token
+
+# This should succeed.
+az monitor action-group delete --name ag-orphan --resource-group <rgName> --acquire-policy-token
+```
+
+### Cleanup
+
+```powershell
+# Drop assignment + definition (see Step 11 in test-flow.http), then:
+az group delete -n <rgName> --yes
+```

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/03-denyaction-actiongroup-in-use/policy-definition.json
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/03-denyaction-actiongroup-in-use/policy-definition.json
@@ -1,0 +1,53 @@
+{
+  "properties": {
+    "displayName": "Block delete of an Action Group that is still referenced by alert rules",
+    "description": "Denies DELETE of Microsoft.Insights/actionGroups when any metric alert, scheduled query rule, or activity log alert in the same subscription still references the action group. Prevents silently breaking on-call paging by orphaning alert rule action targets.",
+    "policyType": "Custom",
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": { "displayName": "Effect" },
+        "allowedValues": [ "auditAction", "denyAction", "disabled" ],
+        "defaultValue": "auditAction"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Insights/actionGroups"
+          },
+          {
+            "value": "[bool(coalesce(claims().isReferenced, false()))]",
+            "equals": true
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "actionNames": [ "delete" ]
+        }
+      }
+    },
+    "externalEvaluationEnforcementSettings": {
+      "missingTokenAction": "deny",
+      "resultLifespan": "PT1H",
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+      ],
+      "endpointSettings": {
+        "kind": "AzureResourceGraph",
+        "details": {
+          "query": "[format('resources | where type in~ (\"microsoft.insights/metricalerts\",\"microsoft.insights/scheduledqueryrules\",\"microsoft.insights/activitylogalerts\") | where tostring(properties) contains \"{0}\" | summarize refCount = count() | project isReferenced = refCount > 0', field('id'))]",
+          "queryProjectedClaims": [
+            "isReferenced"
+          ],
+          "queryWithUserIdentity": true
+        }
+      }
+    }
+  }
+}

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/03-denyaction-actiongroup-in-use/test-flow.http
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/examples/03-denyaction-actiongroup-in-use/test-flow.http
@@ -1,0 +1,282 @@
+# test-flow.http — Block DELETE of an Action Group still referenced by alert rules.
+# Self-contained e2e test: creates RG, creates 3 test resources, creates and assigns
+# the policy, runs deny/allow cases, cleans up.
+# Replace the @-variables below, then send requests in order.
+
+### Variables
+
+# User auth token with the "Bearer " prefix. Acquire via `armclient token` (http://aka.ms/armclient).
+@tok = Bearer <token>
+@host = https://management.azure.com
+@subId = <your-subscription-id>
+@rgName = <your-resource-group-name>
+@location = eastus
+@agReferenced = ag-referenced
+@agOrphan = ag-orphan
+@alertName = alert-test
+@policyName = denyaction-actiongroup-in-use
+@apiVersion = 2025-03-01
+@tokenApiVersion = 2025-11-01
+@agApiVersion = 2023-01-01
+@alertApiVersion = 2020-10-01
+@rgApiVersion = 2021-04-01
+@argApiVersion = 2022-10-01
+
+###############################################################################
+### 1. Create the test resource group
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}?api-version={{rgApiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "location": "{{location}}"
+}
+
+###############################################################################
+### 2. Create the action group that WILL be referenced (ag-referenced)
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agReferenced}}?api-version={{agApiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "location": "Global",
+  "properties": {
+    "groupShortName": "agref",
+    "enabled": true
+  }
+}
+
+###############################################################################
+### 3. Create the orphan action group (ag-orphan)
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agOrphan}}?api-version={{agApiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "location": "Global",
+  "properties": {
+    "groupShortName": "agorph",
+    "enabled": true
+  }
+}
+
+###############################################################################
+### 4. Create an activity log alert pointing at ag-referenced.
+###    This is what makes ag-referenced "in use" from ARG's perspective.
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/activityLogAlerts/{{alertName}}?api-version={{alertApiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "location": "Global",
+  "properties": {
+    "scopes": [ "/subscriptions/{{subId}}" ],
+    "condition": {
+      "allOf": [
+        { "field": "category", "equals": "Administrative" },
+        { "field": "level", "equals": "Error" }
+      ]
+    },
+    "actions": {
+      "actionGroups": [
+        { "actionGroupId": "/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agReferenced}}" }
+      ]
+    },
+    "enabled": true
+  }
+}
+
+### Wait ~30-60s for ARG eventual consistency before proceeding — newly created
+### alert rules need to be indexed before the policy's ARG query will see them.
+
+###############################################################################
+### 5. Create policy definition at the subscription scope
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{policyName}}?api-version={{apiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+< ./policy-definition.json
+
+###############################################################################
+### 6. Assign policy to the test resource group with effect=denyAction
+###############################################################################
+# Body is inlined (rather than `< ./policy-assignment.json`) because the REST
+# Client extension does not expand @-variables inside files included via `<`.
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Authorization/policyAssignments/{{policyName}}?api-version={{apiVersion}}
+Content-Type: application/json
+Authorization: {{tok}}
+
+{
+  "properties": {
+    "displayName": "Assign — block delete of in-use Action Groups",
+    "policyDefinitionId": "/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{policyName}}",
+    "parameters": {
+      "effect": { "value": "denyAction" }
+    }
+  },
+  "name": "{{policyName}}",
+  "location": "{{location}}",
+  "identity": { "type": "systemassigned" }
+}
+
+### Note: queryWithUserIdentity: true is set on the definition, so the caller's
+### identity ({{tok}}) needs Reader on the alert rules being scanned.
+
+###############################################################################
+### 7. CASE A — DELETE the orphan action group. Expect: allowed.
+###    No alert references it → refCount = 0 → isReferenced = false → policy doesn't fire.
+###############################################################################
+
+### 7.1 First DELETE without a token — expect 403 (missingTokenAction: deny)
+DELETE {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agOrphan}}?api-version={{agApiVersion}}
+Authorization: {{tok}}
+
+### Expected: 403 RequestDisallowedByPolicy.
+
+### 7.2 Acquire token for deleting the orphan — expect Allow + token
+
+### Preview the ARG query the policy will run for this DELETE — expect isReferenced: false
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type in~ ('microsoft.insights/metricalerts','microsoft.insights/scheduledqueryrules','microsoft.insights/activitylogalerts') | where tostring(properties) contains '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agOrphan}}' | summarize refCount = count() | project isReferenced = refCount > 0"
+}
+
+### Expected: .data[0].isReferenced == false (or 0). No alerts point at ag-orphan.
+
+# @name tokenDeleteOrphan
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agOrphan}}?api-version={{agApiVersion}}",
+    "httpMethod": "DELETE"
+  }
+}
+
+### Expected: 200 with .results[0].policyAction == "Allow" and a token prefixed "PoP ".
+###           .results[0].claims.isReferenced == false (no alert references ag-orphan).
+
+### 7.3 Retry the DELETE with the token — expect 200/204
+DELETE {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agOrphan}}?api-version={{agApiVersion}}
+Authorization: {{tok}}
+x-ms-policy-external-evaluations: {{tokenDeleteOrphan.response.body.$.token}}
+
+### Expected: 200/204. ag-orphan is gone.
+
+###############################################################################
+### 8. CASE B — Attempt to DELETE the referenced action group. Expect: denied.
+###    alert-test references ag-referenced → refCount = 1 → isReferenced = true → deny.
+###############################################################################
+
+### Preview the ARG query the policy will run for this DELETE — expect isReferenced: true
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type in~ ('microsoft.insights/metricalerts','microsoft.insights/scheduledqueryrules','microsoft.insights/activitylogalerts') | where tostring(properties) contains '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agReferenced}}' | summarize refCount = count() | project isReferenced = refCount > 0"
+}
+
+### Expected: .data[0].isReferenced == true (or 1). alert-test points at ag-referenced.
+
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agReferenced}}?api-version={{agApiVersion}}",
+    "httpMethod": "DELETE"
+  }
+}
+
+### Expected: 200 with .results[0].policyAction == "Deny" and no token.
+###           claims.isReferenced == true.
+###           additionalInfo.requestBody.query shows the materialized KQL.
+
+###############################################################################
+### 9. CASE C — Direct DELETE on the referenced AG without token. Expect: 403.
+###############################################################################
+DELETE {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agReferenced}}?api-version={{agApiVersion}}
+Authorization: {{tok}}
+
+### Expected: 403 RequestDisallowedByPolicy.
+
+###############################################################################
+### 10. CASE D — Remove the reference, then DELETE the AG. Expect: allowed.
+###     Proves the policy is reacting to the reference and not to the AG itself.
+###############################################################################
+
+### 10.1 Delete the alert that references ag-referenced.
+### Note: deleting the alert itself is a DELETE on activityLogAlerts, which the
+### policy does NOT guard (it only guards Microsoft.Insights/actionGroups).
+DELETE {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/activityLogAlerts/{{alertName}}?api-version={{alertApiVersion}}
+Authorization: {{tok}}
+
+### Expected: 200/204. Wait ~30-60s for ARG eventual consistency before next step.
+
+### 10.2 Acquire token to delete the now-unreferenced AG — expect Allow + token
+
+### Preview the ARG query — expect isReferenced: false now that alert-test is gone.
+### If this still shows true, ARG hasn't caught up yet; wait longer.
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "resources | where type in~ ('microsoft.insights/metricalerts','microsoft.insights/scheduledqueryrules','microsoft.insights/activitylogalerts') | where tostring(properties) contains '/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agReferenced}}' | summarize refCount = count() | project isReferenced = refCount > 0"
+}
+
+### Expected: .data[0].isReferenced == false (or 0).
+
+# @name tokenDeleteAfterUnref
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{tok}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agReferenced}}?api-version={{agApiVersion}}",
+    "httpMethod": "DELETE"
+  }
+}
+
+### Expected: Allow + token. claims.isReferenced == false.
+### If still Deny, give ARG more time and retry — eventual consistency.
+
+### 10.3 Retry the DELETE with the token — expect 200/204
+DELETE {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Insights/actionGroups/{{agReferenced}}?api-version={{agApiVersion}}
+Authorization: {{tok}}
+x-ms-policy-external-evaluations: {{tokenDeleteAfterUnref.response.body.$.token}}
+
+### Expected: 200/204. ag-referenced is gone.
+
+###############################################################################
+### 11. Cleanup — remove the policy artifacts and the test RG
+###############################################################################
+DELETE {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Authorization/policyAssignments/{{policyName}}?api-version={{apiVersion}}
+Authorization: {{tok}}
+
+###
+DELETE {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{policyName}}?api-version={{apiVersion}}
+Authorization: {{tok}}
+
+###
+DELETE {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}?api-version={{rgApiVersion}}
+Authorization: {{tok}}

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/knowledge/01-overview.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/knowledge/01-overview.md
@@ -1,0 +1,71 @@
+# 01 - Overview
+
+**External Evaluation** (sometimes called "Invoke" colloquially) allows enforcement policies to incorporate the results of an invocation of an external endpoint into the policy evaluation context, allowing infinite extensibility of enforcement scenarios. Currently this feature only supports the invocation of **Azure Resource Graph (ARG)** queries and using them in the policy conditions, with additional endpoints coming in the future.
+
+## Common patterns
+
+- **Prerequisite checks.** Deny resource operations if some prerequisites (which are expressed by the status of other resources fetched from ARG) are not met.
+- **Existence checks.** Deny resource operations based on the existence of a resource.
+- **Reference checks.** Deny resource operations based on how it's being used/referenced by other resources.
+
+## How it works
+
+### Semantics
+
+"Normal" enforcement policies look only at the body of the ARM request the user is sending. **External Evaluation policies** incorporate additional context fetched from invoking an external endpoint (currently, an **Azure Resource Graph (ARG)** query) in the form of a token attached to the ARM request, allowing the policy to make more complex enforcement decisions.
+
+The semantics of the enforcement rule for these policies is "Deny unless the request attaches a token **proving** that an external endpoint has been invoked and returned an acceptable result". For example, "Deny the association of an NSG to a subnet unless you ran a query that confirms the NSG is not already being used for any other subnets".
+
+### In Practice
+
+- The policy definition has a new `externalEvaluationEnforcementSettings` defining which endpoint to invoke.
+- The results of the endpoint invocation will be encoded into the claims of a special policy token.
+- The `if` condition can use a new `claims()` template function to access the results of the endpoint invocation. e.g. `{ "value": "[claims().isSafe]", "equals": true }`.
+- All expressions in the `if` conditions that are not referencing claims are used to determine the applicability of the policy.
+	- For example, a policy with the condition `if type == vm && tags.env == prod && claims().isSafe == true` is interpreted as "all VMs with `tags[env]` set to `prod` must present a policy token".
+
+### Token Acquisition
+
+Before performing a resource operation protected by an external evaluation policy, the user (or the client they're using) must acquire a policy token that attests that all relevant external endpoints have been invoked and to their results.
+
+This is done with a single call to a new subscription-level `acquirePolicyToken` API call [API Docs](https://learn.microsoft.com/en-us/rest/api/policy-authorization/policy-tokens/acquire?view=rest-policy-authorization-2025-11-01&tabs=HTTP). The semantics of this API is "I want to perform operation X, give me a policy token that fulfils all external evaluation prerequisites". The token API takes care of finding the relevant policies, invoking their endpoints, and signing their results into a single token.
+
+The user (or the client tool) will then attach the token to the ARM resource operation in the `x-ms-policy-external-evaluations` header.
+
+### Compliance
+
+External Evaluation policies make their enforcement decision from data that only exists when (and is only relevant to) a specific resource operation is attempted, so there is no resource-state signal to scan on a schedule. As a result, the standard compliance surface will simply mark all applicable resources as compliant; the real enforcement signal is the per-operation token acquisition result.
+
+## Known limits
+
+### Client tool support
+
+The feature heavily relies on the ability of client tools to "understand" the new concept of a policy token and either acquire it for the user, or provide the user with a knob to acquire it themselves.
+
+Supported tools:
+- Azure Portal — automatically intercepts request failures due to a missing token, acquires the token, and retries the request.
+- Azure Template Deployments — automatically intercept request failures for resources within the template due to a missing token, acquire the token, and retry the request.
+- Azure CLI — global `--acquire-policy-token` flag was added to all commands starting from version 2.85.0.
+
+Known client issues:
+- Tag updates via `Microsoft.Resources/tags` are not evaluated.
+	- When tags are updated via the [tags-as-a-resource API](https://learn.microsoft.com/en-us/rest/api/resources/tags/update-at-scope?view=rest-resources-2021-04-01), which is used by major clients like Azure Portal, the token acquisition will be performed against the tag "resource" instead of the underlying resource actually containing the tags. This essentially means that external evaluation policies that target resource tags (e.g. `../examples/02-deny-immutable-tag-on-nsg/policy-definition.json`) are incompatible with this API and the tag update operations will always be blocked.
+	- *Fix status:* Policy team is working to make the tags API invoke-policy-aware
+
+### Platform limits
+
+- To acquire a policy token, the user must be at least reader at the subscription level as well as have permissions to perform the operation the token is acquired for.
+- Only the `deny`, `audit`, `denyAction` and `auditAction` effects are supported.
+- Endpoint invocation is typically using the policy assignment's MSI, which could lead to throttling if the endpoint has throttling limits by app id.
+	- In the case of ARG queries, the endpoint provides an option to use the caller's identity to query ARG, which should mitigate the issue.
+
+### ARG Endpoint limits, gotchas and quirks
+
+- Queries are being executed at the subscription level. No cross-subscription queries at this stage.
+- The ARG query must return 0 or 1 rows.
+	- The single row value column is translated to a claim accessible by the `if` conditions. e.g. the ARG query `resources | take 1 | project id` will return a single resource id, which the `if` condition can access with the `[claims().id]` expression.
+	- When 0 rows are returned, the claim for each column will be assigned a null value.
+- The ARG endpoint can only return a single column (aka claim). For scenarios where the policy needs multiple pieces of information, they should be consolidated in the ARG query into a single column.
+- Boolean claims arrive as `0`/`1` integers, not `true`/`false`
+	- KQL booleans projected from ARG (`project isFoo = <bool expression>`) are serialized into the policy claim as the integers `1` (true) or `0` (false), not as JSON booleans.
+	- *Workaround:* when expecting a boolean response from the ARG query, wrap the claim expression with `bool(...)` in the rule expression — `[bool(coalesce(claims().isFoo, false()))]` — to coerce the integer back to a real boolean. See `02-policy-artifacts-shape.md` under `policyRule.if` for the full pattern.

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/knowledge/02-policy-artifacts-shape.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/knowledge/02-policy-artifacts-shape.md
@@ -1,0 +1,347 @@
+# 02 — Policy artifacts shape (definition + assignment)
+
+Authoritative JSON shapes for an External Evaluation + ARG policy **definition** and its **assignment**. Both bodies are required; runtime behavior is a function of how they fit together. Base your policy on these. Don't improvise.
+
+---
+
+## The two artifacts, end to end
+
+NSG over-sharing example (from `examples/01-deny-nsg-overshared/`).
+
+### Definition
+
+Official docs:
+- https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure-basics
+- https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure-policy-rule
+- https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure-alias
+
+> Note that official docs don't cover external evaluations as this feature is still in private preview.
+
+```jsonc
+{
+  "properties": {
+    "displayName": "Deny attaching an NSG to subnet if the NSG is already attached to a different subnet",
+    "description": "Denies attaching a Network Security Group to a subnet when the same NSG is already attached to a different subnet in the subscription. Triggers on subnet PUT/PATCH operations that set a networkSecurityGroup reference; subnet operations without an NSG reference, and unrelated NSG updates, are unaffected.",
+    "policyType": "Custom",
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": { "displayName": "Effect" },
+        "allowedValues": [ "audit", "deny", "disabled" ],
+        "defaultValue": "audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/virtualNetworks/subnets"
+          },
+          {
+            "field": "Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id",
+            "notEquals": ""
+          },
+          {
+            "value": "[claims().otherSubnetsCount]",
+            "greater": 0
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    },
+    "externalEvaluationEnforcementSettings": {
+      "missingTokenAction": "deny",
+      "resultLifespan": "PT1H",
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+      ],
+      "endpointSettings": {
+        "kind": "AzureResourceGraph",
+        "details": {
+          "query": "[format('resources | where type =~ \"microsoft.network/networksecuritygroups\" | where id == \"{0}\" | mv-expand subnet = properties[\"subnets\"] | where isnotnull(subnet[\"id\"]) | where subnet[\"id\"] !~ \"{1}\" | summarize otherSubnetsCount = count()', field('Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id'), field('id'))]",
+          "queryProjectedClaims": [
+            "otherSubnetsCount"
+          ],
+          "queryWithUserIdentity": true
+        }
+      }
+    }
+  }
+}
+```
+
+### Assignment
+
+```jsonc
+PUT https://management.azure.com/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Authorization/policyAssignments/deny-nsg-overshared?api-version=2025-03-01
+
+{
+  "properties": {
+    "displayName": "Assign — deny NSG over-sharing",
+    "policyDefinitionId": "/subscriptions/{sub}/providers/Microsoft.Authorization/policyDefinitions/deny-nsg-overshared",
+    "parameters": {
+      "effect": { "value": "deny" }
+    }
+  },
+  "name": "deny-nsg-overshared",
+  "type": "Microsoft.Authorization/policyassignments",
+  "location": "centralus",
+  "identity": { "type": "systemassigned" }
+}
+```
+
+---
+
+## Where `externalEvaluationEnforcementSettings` lives
+
+It is a new property, a **sibling of `policyRule`**, directly under `properties`.
+
+```jsonc
+"properties": {
+  "policyRule": { … },                          // standard if/then
+  "externalEvaluationEnforcementSettings": {    // ← sibling
+    "endpointSettings": { … }
+  }
+}
+```
+
+---
+
+## Definition, field by field
+
+Walk top to bottom through the definition above. Each subsection: *what it is*, *what to set*, *leeway*, *see*.
+
+### Envelope: `displayName`, `description`, `policyType`
+
+*What it is.* Human-facing metadata plus the `Custom` policyType marker. No runtime semantics.
+
+*What to set.*
+- `policyType: "Custom"` — fixed.
+- `displayName` — short label, prefer "<effect> <thing>" (e.g. "Deny NSG over-sharing").
+- `description` — one paragraph stating intent. Surfaced in Portal and `Get-AzPolicyDefinition`.
+
+*Leeway.* `displayName`, `description` are author's call. `policyType` is constant.
+
+---
+
+### `mode`
+
+*What it is.* Controls which resource types the policy engine evaluates.
+
+*What to set.* `"All"`.
+
+*Leeway.* `"Indexed"` is permitted only when the policy targets resource types that support tags and location (except the resource group type). Default to `"All"` whenever you target child types (subnets, role assignments, extension resources). When unsure, `"All"`.
+
+---
+
+### `parameters`
+
+*What it is.* The policy definition parameters. The only parameter the definition exposes. Lets the assignment flip between audit and enforce without editing the definition.
+
+*What to set.* Define an `effect` string parameter so that the policy effect can be decided at assignment time. Definition default is the **audit side** of the family; the assignment overrides to the **enforcement side** (see `parameters.effect.value` under Assignment below). Pick the family from the table based on what kind of ARM op the policy guards.
+
+| Guarded op | Effect family | `allowedValues` | Definition default | Assignment override |
+|---|---|---|---|---|
+| PUT / PATCH on a tracked resource | request-time | `["audit","deny","disabled"]` | `"audit"` | `"deny"` |
+| DELETE | action-time | `["auditAction","denyAction","disabled"]` | `"auditAction"` | `"denyAction"` |
+
+*Leeway.* The two families are not interchangeable — `denyAction` on a PUT silently no-ops. Always include `"disabled"` in `allowedValues` so the assignment can kill the policy without deleting the record.
+
+---
+
+### `policyRule.if`
+
+*What it is.* Standard policy condition language, extended with `claims().<name>` reads against the ARG-side claim. The `allOf` is ordered:
+
+1. `field: "type"` filter on the resource type the policy guards.
+2. *(optional)* `exists` / `field` short-circuit filter — skips the ARG call when the field of interest isn't present in the request body.
+3. The claim check must be aware of the fact that the claim value might be null in the case of no results:
+  -  Expressions like `{ "value": "[claims().otherSubnetsCount]", "notEquals": 0 }`, `{ "value": "[claims().otherSubnetsCount]", "greater": 0 }` will fail evaluation if the ARG query returned no results.
+  - Defensive patterns:
+    - Wrap the expression with `coalesce()`: `[coalesce(claims().otherSubnetsCount, 0)]`.
+    - If the condition needs to explicitly check for null value in the claim, use `[equals(claims().value, null())]`.
+    - **`true`, `false`, and `null` are ARM template *functions*, not literal keywords** inside `[...]` expressions. Always call them: `true()`, `false()`, `null()`. Using the bare word — e.g. `[coalesce(claims().isFoo, false)]` — silently emits the string `"false"`, not the boolean, and the rule will not behave as intended.
+4. When the projected claim is a **boolean**, wrap the read with `bool(...)` to coerce it back from the integer `0`/`1` ARG actually returns over the wire (see `01-overview.md` → Known issues → "Boolean claims arrive as 0/1 integers"). The canonical form combining null-defense, the literal-function trap, and the wire-format coercion is:
+    ```jsonc
+    {
+      "value": "[bool(coalesce(claims().isFoo, false()))]",
+      "equals": true
+    }
+    ```
+    Drop the `bool(...)` wrapper once the underlying ARG fix lands.
+
+*What to set.* The NSG example:
+
+```jsonc
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Network/virtualNetworks/subnets"
+      },
+      {
+        "field": "Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id",
+        "notEquals": ""
+      },
+      {
+        "value": "[claims().otherSubnetsCount]",
+        "greater": 0
+      }
+    ]
+  }
+}
+```
+
+Notes:
+- The claim name on the right of `claims().` **must** match (case-sensitive) the column projected by the KQL (see `endpointSettings.details.query` below) and the single entry in `queryProjectedClaims` (see `queryProjectedClaims` below). Three places, one string.
+- When adding checks on resource properties, you'll need to use the correct policy aliases. If you're not sure, ask the user for help or confirm with them the aliases you think should be used.
+
+*Leeway.* Number of applicability filters is author's call — add them whenever an ARG call would be wasted. The claim check's template-language form is highly recommended but not required. It is intended to protect against operators that might not handle `null` values well. For example, `{ "value": "[claims().X]", "equals": true }` will fail the evaluation in the null case (ARG returned 0 rows).
+
+---
+
+### `policyRule.then.effect`
+
+*What it is.* The effect the rule applies when `if` is true.
+
+*What to set.* Always `"[parameters('effect')]"`.
+
+*Leeway.* None. Don't bake the effect into the definition.
+
+---
+
+### `policyRule.then.details` (action-time effects only)
+
+*What it is.* The companion block to `effect` for the `auditAction` / `denyAction` family. Tells the engine which ARM operation(s) on the targeted resource type the rule guards.
+
+*What to set.* Required when the effect family is action-time. Omit for request-time (`audit` / `deny`).
+
+```jsonc
+"then": {
+  "effect": "[parameters('effect')]",
+  "details": {
+    "actionNames": [ "delete" ]
+  }
+}
+```
+
+- `actionNames` is the list of ARM action verbs the rule should match. For `auditAction`/`denyAction` today, the supported value is `"delete"` — the action-time family exists to guard DELETE.
+- See the [official `auditAction` reference](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/effect-audit-action) for the underlying shape.
+
+*Leeway.* None on action-time effects: the engine rejects the assignment without `details.actionNames`. Don't add this block for request-time effects — it has no meaning there and may fail validation.
+
+---
+
+### `externalEvaluationEnforcementSettings` common fields
+
+*What it is.* The block that makes a policy externally-evaluated. Sibling of `policyRule` (see "Where `externalEvaluationEnforcementSettings` lives" above).
+
+*What to set.*
+
+| Field | Value | Why |
+|---|---|---|
+| `missingTokenAction` | `"deny"` | Controls what happens when the ARM op arrives without a token header. `audit` value makes the token acquisition stage optional, which is useful for advanced scenarios beyond the scope of this skill. |
+| `resultLifespan` | `"PT1H"` | ISO-8601 duration. Arbitrary value that matches the default token expiration time when this property is not specified. |
+| `roleDefinitionIds` | `["/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"]` (Reader) | Declared as the role the assignment MSI would need to invoke the endpoint. Required for all external validation policies. |
+| `endpointSettings.kind` | `AzureResourceGraph` | This is the only supported endpoint |
+| `endpointSettings.details` | An object containing the details of how to invoke the specific endpoint. See `endpointSettings.details.query` below. | NA |
+
+*Leeway.* `resultLifespan` may be shorter than `PT1H`.
+
+---
+
+### `endpointSettings.details.query`
+
+*What it is.* The KQL string the policy service sends to ARG at token-acquisition time to compute the projected claim.
+
+*What to set.* A KQL string wrapped in `[format(...)]` with `field(...)`/`parameters(...)` references for everything that should come from the resource evaluation context. From the NSG example:
+
+```jsonc
+"query": "[format('resources | where type =~ \"microsoft.network/networksecuritygroups\" | where id == \"{0}\" | mv-expand subnet = properties[\"subnets\"] | where isnotnull(subnet[\"id\"]) | where subnet[\"id\"] !~ \"{1}\" | summarize otherSubnetsCount = count()', field('Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id'), field('id'))]"
+```
+
+Notes:
+- `query` is the ARG query **string** — not an object. While it can be a literal query, in reality any meaningful query will require passing fields/parameters from the currently evaluated resource or policy, thus the `[format(...)]` pattern is what most policies will use, where we have a template of the query string that's being dynamically constructed at token acquisition time.
+- Pass `field(...)` and or `parameters(...)` expressions to the query `format()`ing expression to parameterize the query with the necessary runtime values. Both resolve **server-side**, before the materialized KQL is sent to ARG.
+- In advanced scenarios, you can pass more complex values to the query. For example, if evaluating an NSG and the query needs the number of rules, it can be passed to the query with the expression `length(field(...))`.
+- **Dynamic / parameterized field paths.** When the property the query needs to read is itself selected by a policy parameter — e.g. "the value of a tag whose name is `parameters('tagName')`" — combine `field(...)` with `concat(...)`: `field(concat('tags[', parameters('tagName'), ']'))`. This lets a single definition serve many assignments, each pointing at a different field.
+- **Defending against an absent field.** A `field(...)` reference to a property the incoming request body does not contain resolves to `null`, which gets emitted into the materialized KQL as the literal string `"null"` and will silently break query semantics (e.g. a `where existingTag != "null"` comparison passes when the tag was actually omitted). Wrap optional fields with `coalesce(..., '')` (or another sentinel that's safe inside your KQL): `coalesce(field(concat('tags[', parameters('tagName'), ']')), '')`. This is what makes "user is deleting the tag" round-trip cleanly as the empty string the KQL can compare against. Combining the two idioms is common: `coalesce(field(concat('tags[', parameters('tagName'), ']')), '')`.
+- Query must produce **0 or 1 rows**. Multi-row results are rejected with `ExternalEvaluationAzureResourceGraphTooManyRows`. Typical queries either target a specific resource by its id (which will always return 1 or 0 rows). In more advanced cases, use `summarize` (no `by` clause) or `take 1` statements to ensure a single result is returned at most.
+- Carefully escape all the quotes in the ARG query format string.
+- Implicitly scoped to **the single subscription** the ARM op is in. The Policy service pins `subscriptions: ["{sub}"]` on the outbound call — you cannot widen the query. Cross-sub / cross-tenant / MG-scoped invariants are not a fit for this feature.
+
+*Leeway.* Query shape is author's call. Project an **affirmative** boolean — `true` means "the world is in the state the policy cares about" — or a scalar that the rule can compare with `greater` / `less` / `equals`.
+
+*Caveats.*
+- **ARG eventual consistency.** ARG is the standard product; newly created resources may not appear for seconds to minutes. "Deny if a sibling exists" can produce false negatives during that window; "deny unless a sibling exists" can produce false positives. There is no mitigation in the Policy layer — account for it in the policy's intent and error message.
+- **RBAC visibility.** ARG honors the caller's RBAC (or the MSI's, with `queryWithUserIdentity: false`). Resources the identity cannot read are simply absent from the result — indistinguishable from "doesn't exist". Zero rows never means "the resource isn't there"; it means "isn't there or isn't visible to me".
+
+---
+
+### `queryProjectedClaims` and `queryWithUserIdentity`
+
+*What it is.* The contract between ARG result and policy rule. `queryProjectedClaims` names the single column the rule reads via `claims().<name>`. `queryWithUserIdentity` picks whose identity the ARG query uses.
+
+*What to set.*
+
+```jsonc
+"queryProjectedClaims": [ "otherSubnetsCount" ],
+"queryWithUserIdentity": true
+```
+
+Locks:
+- `queryProjectedClaims` is an array of **exactly one** string. Collapse multi-fact logic inside KQL with `summarize`, `iif`, `bag_pack`, etc.
+- The string must equal the KQL column name (`summarize otherSubnetsCount = …`) and the `claims().otherSubnetsCount` reference in the rule. Case-sensitive.
+- `queryWithUserIdentity: true` — use the caller's identity (OBO). Avoids MSI-tier throttling, MSI principal-propagation wait, and the role-assignment step in the test loop.
+
+*Leeway.* `queryWithUserIdentity: false` (MSI mode) is permitted only when the MSI must see resources the caller cannot. Rare. Switching to MSI mode means the assignment's MSI needs the actual role assignment, and the test loop adds principal- and RBAC-propagation waits.
+
+---
+
+## Assignment, field by field
+
+The assignment body shown above.
+
+### `policyDefinitionId`
+
+*What it is.* Full resource id of the definition the assignment is binding.
+
+*What to set.* `"/subscriptions/{sub}/providers/Microsoft.Authorization/policyDefinitions/<defName>"`.
+
+*Leeway.* The assignment's scope (the URL) can be narrower than the definition's home sub — RG-scoped or single-resource-scoped. The definition id itself must match exactly.
+
+---
+
+### `parameters.effect.value`
+
+*What it is.* Override of the `effect` parameter from the definition default.
+
+*What to set.* The **enforcement** side of the family — `"deny"` for request-time, `"denyAction"` for action-time. The definition default is the audit side; the assignment is what turns enforcement on.
+
+*Leeway.* `"audit"` / `"auditAction"` for an audit-only rollout, `"disabled"` to keep the assignment record but skip evaluation. Match `missingTokenAction` in the definition (see `externalEvaluationEnforcementSettings` common fields above) to the assignment-side value.
+
+---
+
+### `identity.type` and `location`
+
+*What it is.* The system-assigned MSI record on the assignment.
+
+*What to set.*
+
+```jsonc
+"identity": { "type": "systemassigned" },
+"location": "centralus"
+```
+
+Locks:
+- `identity.type = "systemassigned"` is **mandatory** on External Evaluation assignments, even when `queryWithUserIdentity: true` means the MSI isn't used at ARG-call time. Validation rejects the assignment without it.
+- `location` is required whenever there's a system-assigned identity. Any valid region works.
+
+*Leeway.* `location` value is author's call. `identity.type` is locked.
+
+---

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/knowledge/03-rest-flow.md
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/knowledge/03-rest-flow.md
@@ -1,0 +1,64 @@
+# 03 — REST contracts
+
+Reference for the wire shapes the `.http` flow uses. The flow itself lives in `templates/test-flow.template.http` and `examples/01-deny-nsg-overshared/test-flow.http`; this file only documents the parts of the contract that matter when reading responses or debugging.
+
+---
+
+## R0 — API versions
+
+| Operation | API version |
+|---|---|
+| Policy definition / assignment CRUD | `2025-03-01` |
+| `acquirePolicyToken` | `2025-11-01` |
+
+---
+
+## R1 — Reading the `acquirePolicyToken` response
+
+Top-level:
+
+- `result`: `"Succeeded"` means the call ran end-to-end; per-endpoint outcomes live under `results[*]`. `"Failed"` means token acquisition itself failed (e.g. ARG returned an error, query was rejected, gating denied the call) — inspect `message` and per-result `message`; don't retry the ARM op.
+- `token`: present when at least one token was minted. Always prefixed with `"PoP "` (literal three characters + space). Pass verbatim, including the prefix.
+- `tokenId`, `expiration`: identifier and lifetime. The token contents are opaque.
+- `changeReference`: change-safety reference; not used for ARG-backed policies.
+
+Per-result (`results[*]`):
+
+- `policyInfo`: which definition/assignment produced this entry.
+- `result`: per-endpoint invocation result. `"Failed"` means the endpoint (e.g. ARG) errored — no token component for this result.
+- `claims`: the exact key/value pairs your KQL projected. The first place to look when a boolean comes back as `null`, the column name is misspelled, or the projection doesn't match `queryProjectedClaims`.
+
+Also under each result:
+
+- `requestDetails`: echo of the operation the token binds to, including a `contentHash` the retry is checked against.
+- `results[*].endpointKind`: `"AzureResourceGraph"` for the ARG endpoint.
+- `results[*].policyAction`: the engine's verdict. Values: `Allow`, `Audit`, `Deny`, `Error`.
+  - all `Allow` or `Audit` → `token` is returned; retry the ARM op with it.
+  - any `Deny` → no token; the policy will block. Don't retry.
+  - `Error` → see `results[*].policyEvaluationDetails.reason`.
+- `results[*].policyEvaluationDetails.evaluatedExpressions`: the rule expressions the engine evaluated and how each resolved.
+- `results[*].additionalInfo` (ARG endpoints): contains `requestBody.query` — the materialized KQL ARG actually saw, after `field(...)` and `parameters(...)` substitution. Diff this against your authored query to catch escaping bugs.
+
+---
+
+## R2 — Retrying the guarded ARM op
+
+The retry attaches the token via header:
+
+- **Header name**: `x-ms-policy-external-evaluations` — lowercase, dashes. Typos behave exactly like "no header" and re-trigger the missing-token path.
+- **Header value**: the `token` field from the acquire-token response, **verbatim including the `PoP ` prefix** (note the space).
+- **Body**: must match `operation.content` from the acquire-token request byte-for-byte. The token is bound to the request body via the `contentHash` echoed in `requestDetails`; mismatched bodies won't bind.
+
+---
+
+## R3 — The 403 you'll see on the first attempt
+
+PUT the resource the first time, before acquiring a token, and ARM returns `403 RequestDisallowedByPolicy`. The interesting payload sits under `error.additionalInfo[*].info.evaluationDetails.missingPolicyTokenDetails`:
+
+- `shouldDeny`: whether the policy would deny without a token (driven by `missingTokenAction` on the definition).
+- `endpointKind`: `"AzureResourceGraph"` for ARG-backed policies.
+- `endpointDetails`: endpoint-specific metadata. For ARG, the materialized query and the subscription it will run against.
+- `endpointResultLifespan`: ISO-8601 duration the resulting token will be valid for.
+- `isChangeReferenceRequired`: change-safety flag; not used for ARG-backed policies.
+
+Programmatic clients consume this block directly to drive the retry. The `.http` flow walks past the 403 deliberately so authors see it at least once.

--- a/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/templates/test-flow.template.http
+++ b/ExternalEvaluationPolicies/agent-skills/azure-arg-external-evaluation-policy-author/templates/test-flow.template.http
@@ -1,0 +1,131 @@
+# External Evaluation + ARG end-to-end test flow.
+# Replace the @-variables below with values from your environment, then send
+# the requests top-to-bottom. There are no automatic waits — if a step fails
+# due to ARM propagation, resend it.
+#
+# Assumes queryWithUserIdentity: true (the skill's default), so the assignment's
+# MSI is not used at ARG-call time and no role-assignment step is needed.
+
+### Variables
+@host = https://management.azure.com
+@subId = <your-subscription-id>
+@rgName = <your-resource-group-name>
+@defName = <your-policy-definition-name>
+@assignName = <your-policy-assignment-name>
+@apiVersion = 2025-03-01
+@tokenApiVersion = 2025-11-01
+@argApiVersion = 2022-10-01
+# User auth token with the "Bearer " prefix. Can be acquired via `armclient token` (requires http://aka.ms/armclient)
+@armToken = Bearer <token>
+
+###############################################################################
+### Step 1 — Create the policy definition
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{defName}}?api-version={{apiVersion}}
+Authorization: {{armToken}}
+Content-Type: application/json
+
+< ./policy-definition.json
+
+### Expected: 201 Created.
+
+###############################################################################
+### Step 2 — Create the assignment
+###############################################################################
+# Body is inlined (rather than `< ./policy-assignment.json`) because the REST
+# Client extension does not expand @-variables inside files included via `<`.
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/Microsoft.Authorization/policyAssignments/{{assignName}}?api-version={{apiVersion}}
+Authorization: {{armToken}}
+Content-Type: application/json
+
+{
+  "properties": {
+    "displayName": "<assignment display name>",
+    "policyDefinitionId": "/subscriptions/{{subId}}/providers/Microsoft.Authorization/policyDefinitions/{{defName}}",
+    "parameters": {
+      "effect": { "value": "<enforcement-side effect, e.g. deny or denyAction>" }
+    }
+  },
+  "name": "{{assignName}}",
+  "location": "<your-location>",
+  "identity": { "type": "systemassigned" }
+}
+
+### Expected: 201 Created.
+
+###############################################################################
+### Step 3 — Attempt the guarded operation WITHOUT a token (expect 403)
+###############################################################################
+# Replace the line below with your actual guarded ARM call.
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/<RP>/<TYPE>/<NAME>?api-version=<RP_API_VERSION>
+Authorization: {{armToken}}
+Content-Type: application/json
+
+{
+  "location": "<LOCATION>",
+  "properties": { }
+}
+
+### Expected: 403 RequestDisallowedByPolicy. The `missingPolicyTokenDetails`
+### block in the response body carries the endpoint metadata; the acquirePolicyToken
+### URL itself is a constant ARM path (see Step 4).
+
+###############################################################################
+### Step 4 — Acquire a policy token (mirrors step 3 byte-for-byte)
+###############################################################################
+# The `# @name token` directive lets step 5 reference this response as
+# {{token.response.body.$.token}} without copy/paste.
+
+### Preview the ARG query the policy will run for this case. Paste the
+### materialized KQL (with the same field/parameter substitutions the policy
+### would make for this exact request) into the query string below. Lets you
+### tell apart "wrong query" from "wrong policy / wrong token / wrong wiring"
+### in one extra send before acquirePolicyToken.
+POST {{host}}/providers/Microsoft.ResourceGraph/resources?api-version={{argApiVersion}}
+Authorization: {{armToken}}
+Content-Type: application/json
+
+{
+  "subscriptions": [ "{{subId}}" ],
+  "query": "<paste the materialized KQL here, with the same inputs the policy will substitute for this case>"
+}
+
+### Expected: a single-row response whose .data[0].<claimName> matches what
+### the corresponding acquirePolicyToken below will report under
+### .results[0].claims.<claimName>.
+
+# @name token
+POST {{host}}/subscriptions/{{subId}}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={{tokenApiVersion}}
+Authorization: {{armToken}}
+Content-Type: application/json
+x-ms-force-sync: true
+
+{
+  "operation": {
+    "uri": "{{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/<RP>/<TYPE>/<NAME>?api-version=<RP_API_VERSION>",
+    "httpMethod": "PUT",
+    "content": {
+      "location": "<LOCATION>",
+      "properties": { }
+    }
+  }
+}
+
+### Expected (2025-11-01): 200 with .result == "Succeeded".
+###   .results[0].policyAction == "Allow" or "Audit" → .token returned, prefixed "PoP "
+###   .results[0].policyAction == "Deny"             → no token; do not retry
+###   .results[0].claims                              → debug: what your KQL projected
+###   .results[0].additionalInfo.requestBody.query    → debug: materialized KQL ARG saw
+
+###############################################################################
+### Step 5 — Retry the guarded ARM op WITH the token
+###############################################################################
+PUT {{host}}/subscriptions/{{subId}}/resourceGroups/{{rgName}}/providers/<RP>/<TYPE>/<NAME>?api-version=<RP_API_VERSION>
+Authorization: {{armToken}}
+x-ms-policy-external-evaluations: {{token.response.body.$.token}}
+Content-Type: application/json
+
+{
+  "location": "<LOCATION>",
+  "properties": { }
+}


### PR DESCRIPTION
Portable AI skill bundle that helps authors create and dry-test Azure Policy External Evaluation policies that query Azure Resource Graph. Lives alongside the existing externalEvaluationSamples and is consumable by any GitHub Copilot / Claude / similar agent that supports a skill folder.

Bundle contents:
- SKILL.md, README.md: skill entry point and bundle overview.
- knowledge/: overview, policy-artifact shape reference, REST contract reference.
- templates/test-flow.template.http: parameterized end-to-end flow.
- examples/01-deny-nsg-overshared: deny effect, request-time enforcement on subnet PUT/PATCH.
- examples/02-deny-immutable-tag-on-nsg: parameterized deny with null-claim defense.
- examples/03-denyaction-actiongroup-in-use: denyAction effect, DELETE-time enforcement.