### PR TITLE
Add ComputerVision to CustomerManagedKey_Audit policy

### DIFF
--- a/built-in-policies/policyDefinitions/Cognitive Services/CustomerManagedKey_Audit.json
+++ b/built-in-policies/policyDefinitions/Cognitive Services/CustomerManagedKey_Audit.json
@@ -45,7 +45,8 @@
           "ConversationalLanguageUnderstanding",
           "knowledge",
           "TranscriptionIntelligence",
-          "HealthDecisionSupport"
+          "HealthDecisionSupport",
+          "ComputerVision"
         ]
       }
     },


### PR DESCRIPTION
ComputerVision does not allow CMk as it is a stateless service, thus it should be excluded.
Source
https://learn.microsoft.com/en-gb/azure/ai-services/encryption/cognitive-services-encryption-keys-portal